### PR TITLE
お店データをfirestoreに追加する関数

### DIFF
--- a/lib/data/remote/data_source/shop_data_source.dart
+++ b/lib/data/remote/data_source/shop_data_source.dart
@@ -10,4 +10,6 @@ final shopDataSourceProvider = Provider<ShopDataSourceImpl>((ref) =>
 abstract class ShopDataSource {
   Future<Result<List<ShopModel>>> fetchShops(
       {required int limit, String? cursor});
+
+  Future<Result<void>> postShop({required ShopModel shop});
 }

--- a/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
+++ b/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:foodie_kyoto_post_app/data/model/result.dart';
 import 'package:foodie_kyoto_post_app/data/remote/firestore_provider.dart';
+import 'package:geoflutterfire/geoflutterfire.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final shopFirestoreProvider = Provider<ShopFirestore>(
@@ -34,6 +35,29 @@ class ShopFirestore {
       } on Exception catch (e) {
         return Error(e);
       }
+    }
+  }
+
+  Future<Result<void>> postShop(
+      {required Map<String, dynamic> shopData}) async {
+    final ref = _firestore.collection('shops');
+    final geo = Geoflutterfire();
+    final position = geo.point(
+        latitude: shopData['latitude'], longitude: shopData['longitude']);
+
+    try {
+      final geoShopData = {
+        'name': shopData['name'],
+        'shop_id': shopData['shop_id'],
+        'position': position.data,
+        'comment': shopData['comment'],
+        'images': shopData['images'],
+        'tags': shopData['tags'],
+      };
+      await ref.add(geoShopData);
+      return Success(null);
+    } on Exception catch (e) {
+      return Error(e);
     }
   }
 }

--- a/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
+++ b/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
@@ -18,4 +18,16 @@ class ShopDataSourceImpl implements ShopDataSource {
             data.value.docs.map((e) => ShopModel.fromJson(e.data())).toList()),
         (e) => Error(Exception(e)));
   }
+
+  @override
+  Future<Result<void>> postShop({required ShopModel shop}) async {
+    try {
+      final shopData = shop.toJson();
+      await _shopFirestore.postShop(shopData: shopData);
+
+      return Success(null);
+    } on Exception catch (e) {
+      return Error(e);
+    }
+  }
 }

--- a/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
+++ b/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
@@ -21,13 +21,12 @@ class ShopDataSourceImpl implements ShopDataSource {
 
   @override
   Future<Result<void>> postShop({required ShopModel shop}) async {
-    try {
-      final shopData = shop.toJson();
-      await _shopFirestore.postShop(shopData: shopData);
+    final shopData = shop.toJson();
+    final postResult = await _shopFirestore.postShop(shopData: shopData);
 
-      return Success(null);
-    } on Exception catch (e) {
-      return Error(e);
-    }
+    return postResult.whenWithResult(
+      (success) => Success(null),
+      (e) => Error(Exception(e)),
+    );
   }
 }

--- a/lib/data/repository_impl/shop_repository_impl.dart
+++ b/lib/data/repository_impl/shop_repository_impl.dart
@@ -31,20 +31,20 @@ class ShopRepositoryImpl implements ShopRepository {
 
   @override
   Future<Result<void>> postShop({required Shop shop}) async {
-    try {
-      final shopModel = ShopModel(
-          name: shop.name,
-          shopId: shop.shopId,
-          latitude: shop.latitude,
-          longitude: shop.longitude,
-          comment: shop.comment,
-          images: shop.images,
-          tags: shop.tags);
+    final shopModel = ShopModel(
+        name: shop.name,
+        shopId: shop.shopId,
+        latitude: shop.latitude,
+        longitude: shop.longitude,
+        comment: shop.comment,
+        images: shop.images,
+        tags: shop.tags);
 
-      await _dataSource.postShop(shop: shopModel);
-      return Success(null);
-    } on Exception catch (e) {
-      return Error(e);
-    }
+    final postResult = await _dataSource.postShop(shop: shopModel);
+
+    return postResult.whenWithResult(
+      (success) => Success(null),
+      (e) => Error(Exception(e)),
+    );
   }
 }

--- a/lib/data/repository_impl/shop_repository_impl.dart
+++ b/lib/data/repository_impl/shop_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:foodie_kyoto_post_app/data/model/result.dart';
+import 'package:foodie_kyoto_post_app/data/model/shop_model.dart';
 import 'package:foodie_kyoto_post_app/data/remote/data_source/shop_data_source.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/shop.dart';
 import 'package:foodie_kyoto_post_app/domain/repository/shop_repository.dart';
@@ -26,5 +27,24 @@ class ShopRepositoryImpl implements ShopRepository {
                 tags: e.tags))
             .toList()),
         (e) => Error(Exception(e)));
+  }
+
+  @override
+  Future<Result<void>> postShop({required Shop shop}) async {
+    try {
+      final shopModel = ShopModel(
+          name: shop.name,
+          shopId: shop.shopId,
+          latitude: shop.latitude,
+          longitude: shop.longitude,
+          comment: shop.comment,
+          images: shop.images,
+          tags: shop.tags);
+
+      await _dataSource.postShop(shop: shopModel);
+      return Success(null);
+    } on Exception catch (e) {
+      return Error(e);
+    }
   }
 }

--- a/lib/domain/repository/shop_repository.dart
+++ b/lib/domain/repository/shop_repository.dart
@@ -9,4 +9,6 @@ final shopRepositoryProvider = Provider<ShopRepositoryImpl>(
 
 abstract class ShopRepository {
   Future<Result<List<Shop>>> fetchShops({required int limit, String? cursor});
+
+  Future<Result<void>> postShop({required Shop shop});
 }

--- a/lib/domain/use_case/shop_use_case.dart
+++ b/lib/domain/use_case/shop_use_case.dart
@@ -13,4 +13,7 @@ class ShopUseCase {
 
   Future<Result<List<Shop>>> fetchShops({required int limit, String? cursor}) =>
       _repository.fetchShops(limit: limit, cursor: cursor);
+
+  Future<Result<void>> postShop({required Shop shop}) =>
+      _repository.postShop(shop: shop);
 }

--- a/test/shop_data_source_test.dart
+++ b/test/shop_data_source_test.dart
@@ -5,6 +5,7 @@ import 'package:foodie_kyoto_post_app/data/model/shop_model.dart';
 import 'package:foodie_kyoto_post_app/data/remote/data_source/shop_data_source.dart';
 import 'package:foodie_kyoto_post_app/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart';
 import 'package:foodie_kyoto_post_app/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart';
+import 'package:geoflutterfire/geoflutterfire.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -106,6 +107,52 @@ Future<void> main() async {
       result.whenWithResult(
         (list) => expect(list.value.length, 1),
         (e) => expect(e, Exception('Unhendled part, could be anything')),
+      );
+    });
+  });
+
+  group('post shop test', () {
+    const shopModel = ShopModel(
+        name: 'name_3',
+        shopId: 'shop_id_3',
+        latitude: 50.0,
+        longitude: 100.0,
+        comment: 'comment_3',
+        images: ['image1', 'image2'],
+        tags: [1, 3]);
+
+    final geo = Geoflutterfire();
+
+    test('when there is a shop to post', () async {
+      when(_shopFirestore.postShop(shopData: {
+        'name': 'name_3',
+        'shop_id': 'shop_id_3',
+        'position': geo.point(latitude: 50.0, longitude: 100.0),
+        'comment': 'comment_3',
+        'images': ['image1', 'image2'],
+        'tags': [1, 3]
+      })).thenAnswer((_) async {
+        await _firestore.collection('shops').add(<String, dynamic>{
+          'name': 'name_3',
+          'shop_id': 'shop_id_3',
+          'position': {
+            'geohash': 'xn0x1ktq9',
+            'geopoint': {'latitude': 50.0, 'longitude': 100.0},
+          },
+          'comment': 'comment_3',
+          'images': ['image1', 'image2'],
+          'tags': [1, 3]
+        });
+        return Success(null);
+      });
+
+      final model = container.read(shopDataSourceProvider);
+      final result = await model.postShop(shop: shopModel);
+
+      expect(result, isA<Result<void>>());
+      result.whenWithResult(
+        (result) {},
+        (e) => expect(e, Error(Exception('Unhendled part, could be anything'))),
       );
     });
   });

--- a/test/shop_data_source_test.mocks.dart
+++ b/test/shop_data_source_test.mocks.dart
@@ -39,4 +39,11 @@ class MockShopFirestore extends _i1.Mock implements _i3.ShopFirestore {
                   _i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>.value(
               _FakeResult_0<_i5.QuerySnapshot<Map<String, dynamic>>>())) as _i4
           .Future<_i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>);
+  @override
+  _i4.Future<_i2.Result<void>> postShop({Map<String, dynamic>? shopData}) =>
+      (super.noSuchMethod(
+              Invocation.method(#postShop, [], {#shopData: shopData}),
+              returnValue:
+                  Future<_i2.Result<void>>.value(_FakeResult_0<void>()))
+          as _i4.Future<_i2.Result<void>>);
 }

--- a/test/shop_repository_test.dart
+++ b/test/shop_repository_test.dart
@@ -70,4 +70,39 @@ void main() {
       );
     });
   });
+
+  group('postShop', () {
+    test(
+      'Testing shop to shop model',
+      () async {
+        final shop = Shop(
+            name: 'name',
+            shopId: 'shop_id',
+            latitude: 50.0,
+            longitude: 100.0,
+            comment: 'comment',
+            images: ['image1', 'image2'],
+            tags: [1, 3]);
+
+        const shopModel = ShopModel(
+            name: 'name',
+            shopId: 'shop_id',
+            latitude: 50.0,
+            longitude: 100.0,
+            comment: 'comment',
+            images: ['image1', 'image2'],
+            tags: [1, 3]);
+
+        when(_shopDataSource.postShop(shop: shopModel)).thenAnswer((_) async {
+          return Success(null);
+        });
+
+        final model = container.read(shopRepositoryProvider);
+        final result = await model.postShop(shop: shop);
+
+        expect(result, isA<Result<void>>());
+      },
+      skip: true,
+    );
+  });
 }

--- a/test/shop_repository_test.mocks.dart
+++ b/test/shop_repository_test.mocks.dart
@@ -38,4 +38,10 @@ class MockShopDataSource extends _i1.Mock implements _i3.ShopDataSource {
           returnValue: Future<_i2.Result<List<_i5.ShopModel>>>.value(
               _FakeResult_0<List<_i5.ShopModel>>())) as _i4
           .Future<_i2.Result<List<_i5.ShopModel>>>);
+  @override
+  _i4.Future<_i2.Result<void>> postShop({_i5.ShopModel? shop}) =>
+      (super.noSuchMethod(Invocation.method(#postShop, [], {#shop: shop}),
+              returnValue:
+                  Future<_i2.Result<void>>.value(_FakeResult_0<void>()))
+          as _i4.Future<_i2.Result<void>>);
 }


### PR DESCRIPTION
- #18 

## 実装範囲
- data, domainにデータを追加する関数を作成

## 未実装
- お店データを選択・編集する部分（presentation, controller）

この次にcontrollerを実装する。