### PR TITLE
shop id でお店情報をクエリする関数を新規作成

### DIFF
--- a/lib/data/remote/data_source/shop_data_source.dart
+++ b/lib/data/remote/data_source/shop_data_source.dart
@@ -12,4 +12,6 @@ abstract class ShopDataSource {
       {required int limit, String? cursor});
 
   Future<Result<void>> postShop({required ShopModel shop});
+
+  Future<Result<ShopModel>> fetchShopByShopId({required String shopId});
 }

--- a/lib/data/remote/data_source/shop_data_source.dart
+++ b/lib/data/remote/data_source/shop_data_source.dart
@@ -13,5 +13,5 @@ abstract class ShopDataSource {
 
   Future<Result<void>> postShop({required ShopModel shop});
 
-  Future<Result<ShopModel>> fetchShopByShopId({required String shopId});
+  Future<Result<ShopModel?>> fetchShopByShopId({required String shopId});
 }

--- a/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
+++ b/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
@@ -61,7 +61,7 @@ class ShopFirestore {
     }
   }
 
-  Future<Result<QuerySnapshot<Map<String, dynamic>>>> fetchShopByShopId(
+  Future<Result<QuerySnapshot<Map<String, dynamic>>?>> fetchShopByShopId(
       {required String shopId}) async {
     try {
       final shopData = await _firestore

--- a/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
+++ b/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
@@ -60,4 +60,18 @@ class ShopFirestore {
       return Error(e);
     }
   }
+
+  Future<Result<QuerySnapshot<Map<String, dynamic>>>> fetchShopByShopId(
+      {required String shopId}) async {
+    try {
+      final shopData = await _firestore
+          .collection('shops')
+          .where('shop_id', isEqualTo: shopId)
+          .get();
+
+      return Success(shopData);
+    } on Exception catch (e) {
+      return Error(e);
+    }
+  }
 }

--- a/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
+++ b/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
@@ -31,12 +31,20 @@ class ShopDataSourceImpl implements ShopDataSource {
   }
 
   @override
-  Future<Result<ShopModel>> fetchShopByShopId({required String shopId}) async {
+  Future<Result<ShopModel?>> fetchShopByShopId({required String shopId}) async {
     final shopResult = await _shopFirestore.fetchShopByShopId(shopId: shopId);
 
     return shopResult.whenWithResult(
-      (shop) => Success(
-          shop.value.docs.map((e) => ShopModel.fromJson(e.data())).first),
+      (shop) {
+        if (shop.value != null && shop.value!.docs.isNotEmpty) {
+          return Success(shop.value?.docs
+              .map((e) => ShopModel.fromJson(e.data()))
+              .toList()
+              .first);
+        } else {
+          return Success(null);
+        }
+      },
       (e) => Error(Exception(e)),
     );
   }

--- a/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
+++ b/lib/data/remote/data_source_impl/model_data_source_impl/shop_data_source_impl.dart
@@ -29,4 +29,15 @@ class ShopDataSourceImpl implements ShopDataSource {
       (e) => Error(Exception(e)),
     );
   }
+
+  @override
+  Future<Result<ShopModel>> fetchShopByShopId({required String shopId}) async {
+    final shopResult = await _shopFirestore.fetchShopByShopId(shopId: shopId);
+
+    return shopResult.whenWithResult(
+      (shop) => Success(
+          shop.value.docs.map((e) => ShopModel.fromJson(e.data())).first),
+      (e) => Error(Exception(e)),
+    );
+  }
 }

--- a/lib/data/repository_impl/shop_repository_impl.dart
+++ b/lib/data/repository_impl/shop_repository_impl.dart
@@ -47,4 +47,27 @@ class ShopRepositoryImpl implements ShopRepository {
       (e) => Error(Exception(e)),
     );
   }
+
+  @override
+  Future<Result<Shop?>> fetchShopByShopId({required String shopId}) async {
+    final shopResult = await _dataSource.fetchShopByShopId(shopId: shopId);
+
+    return shopResult.whenWithResult(
+      (shop) {
+        if (shop.value != null) {
+          return Success(Shop(
+              name: shop.value!.name,
+              shopId: shop.value!.shopId,
+              latitude: shop.value!.latitude,
+              longitude: shop.value!.longitude,
+              comment: shop.value!.comment,
+              images: shop.value!.images,
+              tags: shop.value!.tags));
+        } else {
+          return Success(null);
+        }
+      },
+      (e) => Error(Exception(e)),
+    );
+  }
 }

--- a/lib/domain/repository/shop_repository.dart
+++ b/lib/domain/repository/shop_repository.dart
@@ -11,4 +11,6 @@ abstract class ShopRepository {
   Future<Result<List<Shop>>> fetchShops({required int limit, String? cursor});
 
   Future<Result<void>> postShop({required Shop shop});
+
+  Future<Result<Shop?>> fetchShopByShopId({required String shopId});
 }

--- a/lib/domain/use_case/shop_use_case.dart
+++ b/lib/domain/use_case/shop_use_case.dart
@@ -16,4 +16,7 @@ class ShopUseCase {
 
   Future<Result<void>> postShop({required Shop shop}) =>
       _repository.postShop(shop: shop);
+
+  Future<Result<Shop?>> fetchShopByShopId({required String shopId}) =>
+      _repository.fetchShopByShopId(shopId: shopId);
 }

--- a/test/shop_data_source_test.dart
+++ b/test/shop_data_source_test.dart
@@ -172,9 +172,30 @@ Future<void> main() async {
       final model = container.read(shopDataSourceProvider);
       final result = await model.fetchShopByShopId(shopId: shopId);
 
-      expect(result, isA<Result<ShopModel>>());
+      expect(result, isA<Result<ShopModel?>>());
       result.whenWithResult(
-        (shop) => expect(shop.value.shopId, shopId),
+        (shop) => expect(shop.value?.shopId, shopId),
+        (e) => expect(e, Error(Exception('Unhendled part, could be anything'))),
+      );
+    });
+
+    test('when there is no shop to return', () async {
+      const shopId = 'shop_id_6';
+      when(_shopFirestore.fetchShopByShopId(shopId: shopId))
+          .thenAnswer((_) async {
+        final shopData = await _firestore
+            .collection('shops')
+            .where('shop_id', isEqualTo: shopId)
+            .get();
+        return Success(shopData);
+      });
+
+      final model = container.read(shopDataSourceProvider);
+      final result = await model.fetchShopByShopId(shopId: shopId);
+
+      expect(result, isA<Result<ShopModel?>>());
+      result.whenWithResult(
+        (shop) => expect(shop.value, null),
         (e) => expect(e, Error(Exception('Unhendled part, could be anything'))),
       );
     });

--- a/test/shop_data_source_test.dart
+++ b/test/shop_data_source_test.dart
@@ -156,4 +156,27 @@ Future<void> main() async {
       );
     });
   });
+
+  group('fetch shop by shop id', () {
+    test('when there is a shop', () async {
+      const shopId = 'shop_id_1';
+      when(_shopFirestore.fetchShopByShopId(shopId: shopId))
+          .thenAnswer((_) async {
+        final shopData = await _firestore
+            .collection('shops')
+            .where('shop_id', isEqualTo: shopId)
+            .get();
+        return Success(shopData);
+      });
+
+      final model = container.read(shopDataSourceProvider);
+      final result = await model.fetchShopByShopId(shopId: shopId);
+
+      expect(result, isA<Result<ShopModel>>());
+      result.whenWithResult(
+        (shop) => expect(shop.value.shopId, shopId),
+        (e) => expect(e, Error(Exception('Unhendled part, could be anything'))),
+      );
+    });
+  });
 }

--- a/test/shop_data_source_test.mocks.dart
+++ b/test/shop_data_source_test.mocks.dart
@@ -46,4 +46,12 @@ class MockShopFirestore extends _i1.Mock implements _i3.ShopFirestore {
               returnValue:
                   Future<_i2.Result<void>>.value(_FakeResult_0<void>()))
           as _i4.Future<_i2.Result<void>>);
+  @override
+  _i4.Future<_i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>
+      fetchShopByShopId({String? shopId}) => (super.noSuchMethod(
+          Invocation.method(#fetchShopByShopId, [], {#shopId: shopId}),
+          returnValue: Future<
+                  _i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>.value(
+              _FakeResult_0<_i5.QuerySnapshot<Map<String, dynamic>>>())) as _i4
+          .Future<_i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>);
 }

--- a/test/shop_data_source_test.mocks.dart
+++ b/test/shop_data_source_test.mocks.dart
@@ -47,11 +47,11 @@ class MockShopFirestore extends _i1.Mock implements _i3.ShopFirestore {
                   Future<_i2.Result<void>>.value(_FakeResult_0<void>()))
           as _i4.Future<_i2.Result<void>>);
   @override
-  _i4.Future<_i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>
+  _i4.Future<_i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>?>>
       fetchShopByShopId({String? shopId}) => (super.noSuchMethod(
           Invocation.method(#fetchShopByShopId, [], {#shopId: shopId}),
           returnValue: Future<
-                  _i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>.value(
-              _FakeResult_0<_i5.QuerySnapshot<Map<String, dynamic>>>())) as _i4
-          .Future<_i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>>>);
+                  _i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>?>>.value(
+              _FakeResult_0<_i5.QuerySnapshot<Map<String, dynamic>>?>())) as _i4
+          .Future<_i2.Result<_i5.QuerySnapshot<Map<String, dynamic>>?>>);
 }

--- a/test/shop_repository_test.dart
+++ b/test/shop_repository_test.dart
@@ -13,11 +13,7 @@ import 'shop_repository_test.mocks.dart';
 
 @GenerateMocks([ShopDataSource])
 void main() {
-  late MockShopDataSource _shopDataSource;
-
-  setUp(() {
-    _shopDataSource = MockShopDataSource();
-  });
+  final _shopDataSource = MockShopDataSource();
 
   final container = ProviderContainer(overrides: [
     shopRepositoryProvider.overrideWithProvider(
@@ -104,5 +100,32 @@ void main() {
       },
       skip: true,
     );
+  });
+
+  group('fetch shop by shop id', () {
+    test('when there is a shop', () async {
+      const shopId = 'shop_id_1';
+      when(_shopDataSource.fetchShopByShopId(shopId: shopId))
+          .thenAnswer((_) async {
+        return Success(const ShopModel(
+            name: 'name',
+            shopId: 'shop_id_1',
+            latitude: 100.0,
+            longitude: 100.0,
+            comment: 'comment',
+            images: ['image_1', 'image_2'],
+            tags: [1, 3]));
+      });
+
+      final model = container.read(shopRepositoryProvider);
+      final result = await model.fetchShopByShopId(shopId: shopId);
+
+      expect(result, isA<Result<Shop?>>());
+
+      result.whenWithResult(
+        (shop) => expect(shop.value?.shopId, 'shop_id_1'),
+        (e) => expect(e, Error(Exception('Unhendled part, could be anything'))),
+      );
+    });
   });
 }

--- a/test/shop_repository_test.mocks.dart
+++ b/test/shop_repository_test.mocks.dart
@@ -44,4 +44,11 @@ class MockShopDataSource extends _i1.Mock implements _i3.ShopDataSource {
               returnValue:
                   Future<_i2.Result<void>>.value(_FakeResult_0<void>()))
           as _i4.Future<_i2.Result<void>>);
+  @override
+  _i4.Future<_i2.Result<_i5.ShopModel?>> fetchShopByShopId({String? shopId}) =>
+      (super.noSuchMethod(
+              Invocation.method(#fetchShopByShopId, [], {#shopId: shopId}),
+              returnValue: Future<_i2.Result<_i5.ShopModel?>>.value(
+                  _FakeResult_0<_i5.ShopModel?>()))
+          as _i4.Future<_i2.Result<_i5.ShopModel?>>);
 }


### PR DESCRIPTION
- #18

新規登録or編集したいお店のplaces idをplaces APIで取得
→ そのIDをもとにFirestoreを検索し、既存であれば取得（**今回ここを実装**）
→ データがnullでなければ登録ページに情報を反映。まだデータがなければ（nullであれば）登録ページには空白かなんかを表示。

- データが未登録であれば、places APIでlocationデータを取得する関数を実行する想定（#32）