### PR TITLE
店舗を登録できるようにする

### DIFF
--- a/lib/data/model/shop_model.dart
+++ b/lib/data/model/shop_model.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @immutable
@@ -16,7 +17,7 @@ class ShopModel {
 
   factory ShopModel.fromJson(Map<String, Object?> json) {
     final position = json['position'] as Map<String, dynamic>;
-    final geoPoint = position['geopoint'];
+    final GeoPoint geoPoint = position['geopoint'];
 
     final dynamicImages = json['images'] as List<dynamic>;
     final images = dynamicImages.cast<String>();
@@ -33,8 +34,8 @@ class ShopModel {
     return ShopModel(
         name: json['name'] as String,
         shopId: json['shop_id'] as String,
-        latitude: geoPoint['latitude'] as double,
-        longitude: geoPoint['longitude'] as double,
+        latitude: geoPoint.latitude,
+        longitude: geoPoint.longitude,
         comment: json['comment'] as String,
         images: images,
         serviceTags: serviceTags,

--- a/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
+++ b/lib/data/remote/data_source_impl/firestore_data_source_impl/shop_firestore.dart
@@ -40,7 +40,7 @@ class ShopFirestore {
 
   Future<Result<void>> postShop(
       {required Map<String, dynamic> shopData}) async {
-    final ref = _firestore.collection('shops');
+    final ref = _firestore.collection('shops').doc(shopData['shopId']);
     final geo = Geoflutterfire();
     final position = geo.point(
         latitude: shopData['latitude'], longitude: shopData['longitude']);
@@ -57,7 +57,7 @@ class ShopFirestore {
         'food_tags': shopData['food_tags'],
         'post_user': shopData['post_user'],
       };
-      await ref.add(geoShopData);
+      await ref.set(geoShopData);
       return Success(null);
     } on Exception catch (e) {
       return Error(e);

--- a/lib/ui/pages/post_shop_page/post_shop_controller.dart
+++ b/lib/ui/pages/post_shop_page/post_shop_controller.dart
@@ -1,11 +1,16 @@
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/shop.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/shop_detail.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/places_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/shop_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/string_use_case.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:http/http.dart' as http;
 
 part 'post_shop_controller.freezed.dart';
 
@@ -26,15 +31,24 @@ class PostShopState with _$PostShopState {
   factory PostShopState.error() = _PostShopStateError;
 }
 
+enum PostResults {
+  abort,
+  empty,
+  success,
+  error,
+}
+
 // shopのstateを変更するのは「投稿」ボタンをタップ直後、Firestoreに保存する直前だけにする。
 class PostShopController extends StateNotifier<PostShopState> {
-  PostShopController(this._shopUseCase, this._placesUseCase, this._shopId)
+  PostShopController(
+      this._shopUseCase, this._placesUseCase, this._stringUseCase, this._shopId)
       : super(PostShopState.loading()) {
     initShopState();
   }
 
   final ShopUseCase _shopUseCase;
   final PlacesUseCase _placesUseCase;
+  final StringUseCase _stringUseCase;
   final String _shopId;
 
   final ImagePicker _picker = ImagePicker();
@@ -44,7 +58,12 @@ class PostShopController extends StateNotifier<PostShopState> {
 
     shopResult.whenWithResult((data) async {
       if (data.value != null) {
-        final _images = data.value!.images.map((e) => XFile(e)).toList();
+        final List<XFile> _images = [];
+        final shopImages = data.value!.images;
+        for (int i = 0; i < shopImages.length; i++) {
+          final _image = await _urlToXFile(shopImages[i], '$i');
+          _images.add(_image);
+        }
 
         state = PostShopState(
           shop: data.value,
@@ -90,6 +109,21 @@ class PostShopController extends StateNotifier<PostShopState> {
     }, (e) {
       state = PostShopState.error();
     });
+  }
+
+  Future<XFile> _urlToXFile(String imageUrl, String fileName) async {
+    Directory tempDir = await getTemporaryDirectory();
+    String tempPath = tempDir.path;
+
+    final File file = File('$tempPath/$fileName.png');
+
+    final url = Uri.parse(imageUrl);
+    final http.Response response = await http.get(url);
+
+    await file.writeAsBytes(response.bodyBytes);
+
+    final xFile = XFile(file.path);
+    return xFile;
   }
 
   void editComment(String body) {
@@ -201,6 +235,75 @@ class PostShopController extends StateNotifier<PostShopState> {
       selectedFoodTags.remove(key);
 
       state = currentState.copyWith(selectedFoodTags: selectedFoodTags);
+    }
+  }
+
+  Future<PostResults> postShop() async {
+    if (state is _PostShopState) {
+      final currentState = state as _PostShopState;
+      if (currentState.shop == null) {
+        return PostResults.abort;
+      }
+
+      if (currentState.comment == '' || currentState.images.isEmpty) {
+        return PostResults.empty;
+      }
+      // コメントが空白、または画像を設定しないまま保存しない
+
+      final deleteResult = await _stringUseCase.deleteImages(shopId: _shopId);
+
+      return deleteResult.whenWithResult((success) async {
+        final imagesUrl = await getImageUrlFromStorage(
+            currentState.images.map((e) => e.path).toList());
+
+        if (imagesUrl.isNotEmpty) {
+          final shop = Shop(
+              name: currentState.shop!.name,
+              shopId: _shopId,
+              latitude: currentState.shop!.latitude,
+              longitude: currentState.shop!.longitude,
+              comment: currentState.comment!,
+              images: imagesUrl,
+              serviceTags: currentState.selectedServiceTags,
+              areaTags: currentState.selectedAreaTags,
+              foodTags: currentState.selectedFoodTags,
+              postUser: 'postUser');
+          // 別issueで登録者ボタンを作るまではとりあえずStringを入れておく。
+
+          final result = await _shopUseCase.postShop(shop: shop);
+          return result.whenWithResult(
+            (success) => PostResults.success,
+            (e) => PostResults.error,
+          );
+        } else {
+          return PostResults.empty;
+        }
+      }, (e) => PostResults.error);
+    } else {
+      return PostResults.abort;
+    }
+  }
+
+  Future<List<String>> getImageUrlFromStorage(List<String> imagePaths) async {
+    if (state is _PostShopState) {
+      for (int i = 0; i < imagePaths.length; i++) {
+        await _stringUseCase.postImages(
+            path: imagePaths[i], shopId: _shopId, fileName: '$i');
+      }
+
+      final List<String> _imageUrlList = <String>[];
+      for (int i = 0; i < imagePaths.length; i++) {
+        final urlResult = await _stringUseCase.getImagesUrl(
+            path: imagePaths[i], shopId: _shopId, fileName: '$i');
+        urlResult.whenWithResult((url) {
+          if (url.value != null) {
+            _imageUrlList.add(url.value!);
+          }
+        }, (failure) {});
+      }
+      return _imageUrlList;
+    } else {
+      return <String>[];
     }
   }
 }

--- a/lib/ui/pages/post_shop_page/post_shop_page.dart
+++ b/lib/ui/pages/post_shop_page/post_shop_page.dart
@@ -1,10 +1,12 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
 import 'package:foodie_kyoto_post_app/constants/tags_data.dart';
 import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
 import 'package:foodie_kyoto_post_app/ui/components/tag_button.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -95,7 +97,34 @@ class PostShopPage extends HookConsumerWidget {
               _FoodTagsWidget(shopId: shopId),
               const SizedBox(height: 4),
               _SelectedTagsWidget(shopId: shopId),
-              const SizedBox(height: 24)
+              const SizedBox(height: 24),
+              ElevatedButton(
+                  onPressed: () {
+                    HapticFeedback.mediumImpact();
+                    ref
+                        .read(postShopProvider(shopId).notifier)
+                        .postShop()
+                        .then((postResults) async {
+                      if (postResults == PostResults.success) {
+                        await showDialog(
+                            context: context,
+                            builder: (context) {
+                              return const OkDialog(
+                                  title: 'SUCCESS!', body: '登録に成功しました。');
+                            });
+                      }
+                    });
+                  },
+                  style: ElevatedButton.styleFrom(
+                    primary: AppColors.appPink,
+                    shape: const StadiumBorder(),
+                    elevation: 2,
+                  ),
+                  child: const Text(
+                    '登録',
+                    style: TextStyle(color: AppColors.appBlack, fontSize: 16),
+                  )),
+              const SizedBox(height: 24),
             ],
           ),
         );

--- a/lib/ui/pages/post_shop_page/post_shop_provider.dart
+++ b/lib/ui/pages/post_shop_page/post_shop_provider.dart
@@ -1,9 +1,13 @@
 import 'package:foodie_kyoto_post_app/domain/use_case/places_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/shop_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/string_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final postShopProvider = StateNotifierProvider.family
     .autoDispose<PostShopController, PostShopState, String>((ref, _shopId) =>
-        PostShopController(ref.read(shopUseCaseProvider),
-            ref.read(placesUseCaseProvider), _shopId));
+        PostShopController(
+            ref.read(shopUseCaseProvider),
+            ref.read(placesUseCaseProvider),
+            ref.read(stringUseCaseProvider),
+            _shopId));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
 
   # Misc
   image_picker: ^0.8.5+3
+  path_provider: ^2.0.10
 
 dev_dependencies:
   flutter_test:

--- a/test/model/shop_model_test.dart
+++ b/test/model/shop_model_test.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:foodie_kyoto_post_app/data/model/shop_model.dart';
 
@@ -8,7 +9,7 @@ void main() {
       'shop_id': 'shop_id_1',
       'position': {
         'geohash': 'xn0x1ktq9',
-        'geopoint': {'latitude': 35.006323, 'longitude': 135.765321},
+        'geopoint': const GeoPoint(35.006323, 135.765321),
       },
       'comment': 'comment_1',
       'images': ['image1', 'image2'],
@@ -23,7 +24,7 @@ void main() {
       'shop_id': 'shop_id_2',
       'position': {
         'geohash': 'xn0x1ktq9',
-        'geopoint': {'latitude': 35.006323, 'longitude': 135.765321},
+        'geopoint': const GeoPoint(35.006323, 135.765321),
       },
       'comment': 'comment_2',
       'images': ['image1', 'image2'],

--- a/test/post_shop_controller_test.dart
+++ b/test/post_shop_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:foodie_kyoto_post_app/domain/entity/shop.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/shop_detail.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/places_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/shop_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/string_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -14,17 +15,18 @@ import 'package:mockito/mockito.dart';
 
 import 'post_shop_controller_test.mocks.dart';
 
-@GenerateMocks([ShopUseCase, PlacesUseCase, ImagePicker, XFile])
+@GenerateMocks([ShopUseCase, PlacesUseCase, StringUseCase, XFile, ImagePicker])
 void main() {
   final _shopUseCase = MockShopUseCase();
   final _placesUseCase = MockPlacesUseCase();
+  final _stringUseCase = MockStringUseCase();
   final _picker = MockImagePicker();
 
   final container = ProviderContainer(overrides: [
     postShopProvider.overrideWithProvider(StateNotifierProvider.family
         .autoDispose<PostShopController, PostShopState, String>(
-            (ref, _shopId) =>
-                PostShopController(_shopUseCase, _placesUseCase, _shopId))),
+            (ref, _shopId) => PostShopController(
+                _shopUseCase, _placesUseCase, _stringUseCase, _shopId))),
   ]);
 
   group('init shop state', () {

--- a/test/post_shop_controller_test.mocks.dart
+++ b/test/post_shop_controller_test.mocks.dart
@@ -15,7 +15,9 @@ import 'package:foodie_kyoto_post_app/domain/use_case/places_use_case.dart'
     as _i7;
 import 'package:foodie_kyoto_post_app/domain/use_case/shop_use_case.dart'
     as _i4;
-import 'package:image_picker/image_picker.dart' as _i10;
+import 'package:foodie_kyoto_post_app/domain/use_case/string_use_case.dart'
+    as _i10;
+import 'package:image_picker/image_picker.dart' as _i13;
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart'
     as _i3;
 import 'package:mockito/mockito.dart' as _i1;
@@ -32,12 +34,12 @@ import 'package:mockito/mockito.dart' as _i1;
 
 class _FakeResult_0<T> extends _i1.Fake implements _i2.Result<T> {}
 
-class _FakeLostData_1 extends _i1.Fake implements _i3.LostData {}
+class _FakeDateTime_1 extends _i1.Fake implements DateTime {}
 
-class _FakeLostDataResponse_2 extends _i1.Fake implements _i3.LostDataResponse {
+class _FakeLostData_2 extends _i1.Fake implements _i3.LostData {}
+
+class _FakeLostDataResponse_3 extends _i1.Fake implements _i3.LostDataResponse {
 }
-
-class _FakeDateTime_3 extends _i1.Fake implements DateTime {}
 
 /// A class which mocks [ShopUseCase].
 ///
@@ -101,10 +103,90 @@ class MockPlacesUseCase extends _i1.Mock implements _i7.PlacesUseCase {
           as _i5.Future<_i2.Result<_i9.ShopDetail?>>);
 }
 
+/// A class which mocks [StringUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockStringUseCase extends _i1.Mock implements _i10.StringUseCase {
+  MockStringUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i5.Future<_i2.Result<String?>> postImages(
+          {String? path, String? shopId, String? fileName}) =>
+      (super.noSuchMethod(
+              Invocation.method(#postImages, [],
+                  {#path: path, #shopId: shopId, #fileName: fileName}),
+              returnValue:
+                  Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
+          as _i5.Future<_i2.Result<String?>>);
+  @override
+  _i5.Future<_i2.Result<String?>> getImagesUrl(
+          {String? path, String? shopId, String? fileName}) =>
+      (super.noSuchMethod(
+              Invocation.method(#getImagesUrl, [],
+                  {#path: path, #shopId: shopId, #fileName: fileName}),
+              returnValue:
+                  Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
+          as _i5.Future<_i2.Result<String?>>);
+  @override
+  _i5.Future<_i2.Result<String>> deleteImages({String? shopId}) => (super
+          .noSuchMethod(Invocation.method(#deleteImages, [], {#shopId: shopId}),
+              returnValue:
+                  Future<_i2.Result<String>>.value(_FakeResult_0<String>()))
+      as _i5.Future<_i2.Result<String>>);
+}
+
+/// A class which mocks [XFile].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockXFile extends _i1.Mock implements _i3.XFile {
+  MockXFile() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  String get path =>
+      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
+  @override
+  String get name =>
+      (super.noSuchMethod(Invocation.getter(#name), returnValue: '') as String);
+  @override
+  _i5.Future<void> saveTo(String? path) =>
+      (super.noSuchMethod(Invocation.method(#saveTo, [path]),
+          returnValue: Future<void>.value(),
+          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
+  @override
+  _i5.Future<int> length() =>
+      (super.noSuchMethod(Invocation.method(#length, []),
+          returnValue: Future<int>.value(0)) as _i5.Future<int>);
+  @override
+  _i5.Future<String> readAsString(
+          {_i11.Encoding? encoding = const _i11.Utf8Codec()}) =>
+      (super.noSuchMethod(
+          Invocation.method(#readAsString, [], {#encoding: encoding}),
+          returnValue: Future<String>.value('')) as _i5.Future<String>);
+  @override
+  _i5.Future<_i12.Uint8List> readAsBytes() =>
+      (super.noSuchMethod(Invocation.method(#readAsBytes, []),
+              returnValue: Future<_i12.Uint8List>.value(_i12.Uint8List(0)))
+          as _i5.Future<_i12.Uint8List>);
+  @override
+  _i5.Stream<_i12.Uint8List> openRead([int? start, int? end]) =>
+      (super.noSuchMethod(Invocation.method(#openRead, [start, end]),
+              returnValue: Stream<_i12.Uint8List>.empty())
+          as _i5.Stream<_i12.Uint8List>);
+  @override
+  _i5.Future<DateTime> lastModified() =>
+      (super.noSuchMethod(Invocation.method(#lastModified, []),
+              returnValue: Future<DateTime>.value(_FakeDateTime_1()))
+          as _i5.Future<DateTime>);
+}
+
 /// A class which mocks [ImagePicker].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockImagePicker extends _i1.Mock implements _i10.ImagePicker {
+class MockImagePicker extends _i1.Mock implements _i13.ImagePicker {
   MockImagePicker() {
     _i1.throwOnMissingStub(this);
   }
@@ -153,7 +235,7 @@ class MockImagePicker extends _i1.Mock implements _i10.ImagePicker {
   @override
   _i5.Future<_i3.LostData> getLostData() =>
       (super.noSuchMethod(Invocation.method(#getLostData, []),
-              returnValue: Future<_i3.LostData>.value(_FakeLostData_1()))
+              returnValue: Future<_i3.LostData>.value(_FakeLostData_2()))
           as _i5.Future<_i3.LostData>);
   @override
   _i5.Future<_i3.XFile?> pickImage(
@@ -198,52 +280,6 @@ class MockImagePicker extends _i1.Mock implements _i10.ImagePicker {
   _i5.Future<_i3.LostDataResponse> retrieveLostData() =>
       (super.noSuchMethod(Invocation.method(#retrieveLostData, []),
               returnValue:
-                  Future<_i3.LostDataResponse>.value(_FakeLostDataResponse_2()))
+                  Future<_i3.LostDataResponse>.value(_FakeLostDataResponse_3()))
           as _i5.Future<_i3.LostDataResponse>);
-}
-
-/// A class which mocks [XFile].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockXFile extends _i1.Mock implements _i3.XFile {
-  MockXFile() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  String get path =>
-      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
-  @override
-  String get name =>
-      (super.noSuchMethod(Invocation.getter(#name), returnValue: '') as String);
-  @override
-  _i5.Future<void> saveTo(String? path) =>
-      (super.noSuchMethod(Invocation.method(#saveTo, [path]),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
-  @override
-  _i5.Future<int> length() =>
-      (super.noSuchMethod(Invocation.method(#length, []),
-          returnValue: Future<int>.value(0)) as _i5.Future<int>);
-  @override
-  _i5.Future<String> readAsString(
-          {_i11.Encoding? encoding = const _i11.Utf8Codec()}) =>
-      (super.noSuchMethod(
-          Invocation.method(#readAsString, [], {#encoding: encoding}),
-          returnValue: Future<String>.value('')) as _i5.Future<String>);
-  @override
-  _i5.Future<_i12.Uint8List> readAsBytes() =>
-      (super.noSuchMethod(Invocation.method(#readAsBytes, []),
-              returnValue: Future<_i12.Uint8List>.value(_i12.Uint8List(0)))
-          as _i5.Future<_i12.Uint8List>);
-  @override
-  _i5.Stream<_i12.Uint8List> openRead([int? start, int? end]) =>
-      (super.noSuchMethod(Invocation.method(#openRead, [start, end]),
-              returnValue: Stream<_i12.Uint8List>.empty())
-          as _i5.Stream<_i12.Uint8List>);
-  @override
-  _i5.Future<DateTime> lastModified() =>
-      (super.noSuchMethod(Invocation.method(#lastModified, []),
-              returnValue: Future<DateTime>.value(_FakeDateTime_3()))
-          as _i5.Future<DateTime>);
 }

--- a/test/shop_data_source_test.dart
+++ b/test/shop_data_source_test.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:foodie_kyoto_post_app/data/model/result.dart';
@@ -32,7 +33,7 @@ Future<void> main() async {
       'shop_id': 'shop_id_1',
       'position': {
         'geohash': 'xn0x1ktq9',
-        'geopoint': {'latitude': 35.006323, 'longitude': 135.765321},
+        'geopoint': const GeoPoint(35.006323, 135.765321),
       },
       'comment': 'comment_1',
       'images': ['image1', 'image2'],
@@ -50,7 +51,7 @@ Future<void> main() async {
       'shop_id': 'shop_id_2',
       'position': {
         'geohash': 'xn0x1ktq9',
-        'geopoint': {'latitude': 35.006323, 'longitude': 135.765321},
+        'geopoint': const GeoPoint(35.006323, 135.765321),
       },
       'comment': 'comment_2',
       'images': ['image1', 'image2'],
@@ -148,7 +149,7 @@ Future<void> main() async {
           'shop_id': 'shop_id_3',
           'position': {
             'geohash': 'xn0x1ktq9',
-            'geopoint': {'latitude': 50.0, 'longitude': 100.0},
+            'geopoint': const GeoPoint(50.0, 100.0),
           },
           'comment': 'comment_3',
           'images': ['image1', 'image2'],

--- a/test/shop_repository_test.dart
+++ b/test/shop_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:foodie_kyoto_post_app/data/model/result.dart';
 import 'package:foodie_kyoto_post_app/data/model/shop_model.dart';
@@ -29,7 +30,7 @@ void main() {
           'shop_id': 'shop_id_1',
           'position': {
             'geohash': 'xn0x1ktq9',
-            'geopoint': {'latitude': 35.006323, 'longitude': 135.765321},
+            'geopoint': const GeoPoint(35.006323, 135.765321),
           },
           'comment': 'comment_1',
           'images': ['image1', 'image2'],
@@ -44,7 +45,7 @@ void main() {
           'shop_id': 'shop_id_2',
           'position': {
             'geohash': 'xn0x1ktq9',
-            'geopoint': {'latitude': 35.006323, 'longitude': 135.765321},
+            'geopoint': const GeoPoint(35.006323, 135.765321),
           },
           'comment': 'comment_2',
           'images': ['image1', 'image2'],


### PR DESCRIPTION
- #18 を完了させる。

### ここまででできること
- 画像の選択
- レビューの入力
- タグの選択
- 店舗をFirestoreに登録

### まだ残っているやらないといけないこと
- 画像の追加（枚数を増やす）、変更、削除
- 登録者の選択

### 要リファクタ（まだ残っているやらないといけないこと）
- 画像選択・データ変換をservice層に分離(#56)
- スキップしているテストの有効化

