### PR TITLE
画像選択関数をuse caseから呼び出す

### DIFF
--- a/lib/ui/pages/post_shop_page/post_shop_controller.freezed.dart
+++ b/lib/ui/pages/post_shop_page/post_shop_controller.freezed.dart
@@ -22,7 +22,7 @@ mixin _$PostShopState {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)
@@ -37,7 +37,7 @@ mixin _$PostShopState {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?
@@ -52,7 +52,7 @@ mixin _$PostShopState {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?
@@ -112,7 +112,7 @@ abstract class _$$_PostShopStateCopyWith<$Res> {
       {Shop? shop,
       TextEditingController commentController,
       String? comment,
-      List<XFile> images,
+      List<File> images,
       List<int> selectedServiceTags,
       List<int> selectedAreaTags,
       List<int> selectedFoodTags});
@@ -155,7 +155,7 @@ class __$$_PostShopStateCopyWithImpl<$Res>
       images: images == freezed
           ? _value._images
           : images // ignore: cast_nullable_to_non_nullable
-              as List<XFile>,
+              as List<File>,
       selectedServiceTags: selectedServiceTags == freezed
           ? _value._selectedServiceTags
           : selectedServiceTags // ignore: cast_nullable_to_non_nullable
@@ -179,7 +179,7 @@ class _$_PostShopState implements _PostShopState {
       {required this.shop,
       required this.commentController,
       required this.comment,
-      final List<XFile> images = const [],
+      final List<File> images = const [],
       final List<int> selectedServiceTags = const [],
       final List<int> selectedAreaTags = const [],
       final List<int> selectedFoodTags = const []})
@@ -194,10 +194,10 @@ class _$_PostShopState implements _PostShopState {
   final TextEditingController commentController;
   @override
   final String? comment;
-  final List<XFile> _images;
+  final List<File> _images;
   @override
   @JsonKey()
-  List<XFile> get images {
+  List<File> get images {
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_images);
   }
@@ -272,7 +272,7 @@ class _$_PostShopState implements _PostShopState {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)
@@ -291,7 +291,7 @@ class _$_PostShopState implements _PostShopState {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?
@@ -310,7 +310,7 @@ class _$_PostShopState implements _PostShopState {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?
@@ -366,7 +366,7 @@ abstract class _PostShopState implements PostShopState {
       {required final Shop? shop,
       required final TextEditingController commentController,
       required final String? comment,
-      final List<XFile> images,
+      final List<File> images,
       final List<int> selectedServiceTags,
       final List<int> selectedAreaTags,
       final List<int> selectedFoodTags}) = _$_PostShopState;
@@ -375,7 +375,7 @@ abstract class _PostShopState implements PostShopState {
   TextEditingController get commentController =>
       throw _privateConstructorUsedError;
   String? get comment => throw _privateConstructorUsedError;
-  List<XFile> get images => throw _privateConstructorUsedError;
+  List<File> get images => throw _privateConstructorUsedError;
   List<int> get selectedServiceTags => throw _privateConstructorUsedError;
   List<int> get selectedAreaTags => throw _privateConstructorUsedError;
   List<int> get selectedFoodTags => throw _privateConstructorUsedError;
@@ -429,7 +429,7 @@ class _$_PostShopStateLoading implements _PostShopStateLoading {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)
@@ -447,7 +447,7 @@ class _$_PostShopStateLoading implements _PostShopStateLoading {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?
@@ -465,7 +465,7 @@ class _$_PostShopStateLoading implements _PostShopStateLoading {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?
@@ -564,7 +564,7 @@ class _$_PostShopStateError implements _PostShopStateError {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)
@@ -582,7 +582,7 @@ class _$_PostShopStateError implements _PostShopStateError {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?
@@ -600,7 +600,7 @@ class _$_PostShopStateError implements _PostShopStateError {
             Shop? shop,
             TextEditingController commentController,
             String? comment,
-            List<XFile> images,
+            List<File> images,
             List<int> selectedServiceTags,
             List<int> selectedAreaTags,
             List<int> selectedFoodTags)?

--- a/lib/ui/pages/post_shop_page/post_shop_provider.dart
+++ b/lib/ui/pages/post_shop_page/post_shop_provider.dart
@@ -1,3 +1,4 @@
+import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/places_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/shop_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/shop_use_case.dart';
@@ -10,4 +11,5 @@ final postShopProvider = StateNotifierProvider.family
             ref.read(shopUseCaseProvider),
             ref.read(placesUseCaseProvider),
             ref.read(shopImageUseCaseProvider),
+            ref.read(imageFileUseCaseProvider),
             _shopId));

--- a/test/post_shop_controller_test.mocks.dart
+++ b/test/post_shop_controller_test.mocks.dart
@@ -2,23 +2,21 @@
 // in foodie_kyoto_post_app/test/post_shop_controller_test.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i5;
-import 'dart:convert' as _i11;
-import 'dart:typed_data' as _i12;
+import 'dart:async' as _i4;
+import 'dart:io' as _i11;
 
 import 'package:foodie_kyoto_post_app/data/model/result.dart' as _i2;
 import 'package:foodie_kyoto_post_app/domain/entity/foodie_prediction.dart'
-    as _i8;
-import 'package:foodie_kyoto_post_app/domain/entity/shop.dart' as _i6;
-import 'package:foodie_kyoto_post_app/domain/entity/shop_detail.dart' as _i9;
-import 'package:foodie_kyoto_post_app/domain/use_case/places_use_case.dart'
     as _i7;
-import 'package:foodie_kyoto_post_app/domain/use_case/shop_image_use_case.dart'
+import 'package:foodie_kyoto_post_app/domain/entity/shop.dart' as _i5;
+import 'package:foodie_kyoto_post_app/domain/entity/shop_detail.dart' as _i8;
+import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart'
     as _i10;
+import 'package:foodie_kyoto_post_app/domain/use_case/places_use_case.dart'
+    as _i6;
+import 'package:foodie_kyoto_post_app/domain/use_case/shop_image_use_case.dart'
+    as _i9;
 import 'package:foodie_kyoto_post_app/domain/use_case/shop_use_case.dart'
-    as _i4;
-import 'package:image_picker/image_picker.dart' as _i13;
-import 'package:image_picker_platform_interface/image_picker_platform_interface.dart'
     as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
@@ -34,48 +32,41 @@ import 'package:mockito/mockito.dart' as _i1;
 
 class _FakeResult_0<T> extends _i1.Fake implements _i2.Result<T> {}
 
-class _FakeDateTime_1 extends _i1.Fake implements DateTime {}
-
-class _FakeLostData_2 extends _i1.Fake implements _i3.LostData {}
-
-class _FakeLostDataResponse_3 extends _i1.Fake implements _i3.LostDataResponse {
-}
-
 /// A class which mocks [ShopUseCase].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockShopUseCase extends _i1.Mock implements _i4.ShopUseCase {
+class MockShopUseCase extends _i1.Mock implements _i3.ShopUseCase {
   MockShopUseCase() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Future<_i2.Result<List<_i6.Shop>>> fetchShops(
+  _i4.Future<_i2.Result<List<_i5.Shop>>> fetchShops(
           {int? limit, String? cursor}) =>
       (super.noSuchMethod(
           Invocation.method(#fetchShops, [], {#limit: limit, #cursor: cursor}),
-          returnValue: Future<_i2.Result<List<_i6.Shop>>>.value(
-              _FakeResult_0<List<_i6.Shop>>())) as _i5
-          .Future<_i2.Result<List<_i6.Shop>>>);
+          returnValue: Future<_i2.Result<List<_i5.Shop>>>.value(
+              _FakeResult_0<List<_i5.Shop>>())) as _i4
+          .Future<_i2.Result<List<_i5.Shop>>>);
   @override
-  _i5.Future<_i2.Result<void>> postShop({_i6.Shop? shop}) =>
+  _i4.Future<_i2.Result<void>> postShop({_i5.Shop? shop}) =>
       (super.noSuchMethod(Invocation.method(#postShop, [], {#shop: shop}),
               returnValue:
                   Future<_i2.Result<void>>.value(_FakeResult_0<void>()))
-          as _i5.Future<_i2.Result<void>>);
+          as _i4.Future<_i2.Result<void>>);
   @override
-  _i5.Future<_i2.Result<_i6.Shop?>> fetchShopByShopId({String? shopId}) =>
+  _i4.Future<_i2.Result<_i5.Shop?>> fetchShopByShopId({String? shopId}) =>
       (super.noSuchMethod(
               Invocation.method(#fetchShopByShopId, [], {#shopId: shopId}),
-              returnValue: Future<_i2.Result<_i6.Shop?>>.value(
-                  _FakeResult_0<_i6.Shop?>()))
-          as _i5.Future<_i2.Result<_i6.Shop?>>);
+              returnValue: Future<_i2.Result<_i5.Shop?>>.value(
+                  _FakeResult_0<_i5.Shop?>()))
+          as _i4.Future<_i2.Result<_i5.Shop?>>);
 }
 
 /// A class which mocks [PlacesUseCase].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPlacesUseCase extends _i1.Mock implements _i7.PlacesUseCase {
+class MockPlacesUseCase extends _i1.Mock implements _i6.PlacesUseCase {
   MockPlacesUseCase() {
     _i1.throwOnMissingStub(this);
   }
@@ -85,201 +76,76 @@ class MockPlacesUseCase extends _i1.Mock implements _i7.PlacesUseCase {
       Invocation.method(#initGooglePlaces, [], {#apiKey: apiKey}),
       returnValueForMissingStub: null);
   @override
-  _i5.Future<_i2.Result<List<_i8.FoodiePrediction>>> searchShopsByAutoComplete(
+  _i4.Future<_i2.Result<List<_i7.FoodiePrediction>>> searchShopsByAutoComplete(
           {String? body}) =>
       (super.noSuchMethod(
               Invocation.method(#searchShopsByAutoComplete, [], {#body: body}),
-              returnValue: Future<_i2.Result<List<_i8.FoodiePrediction>>>.value(
-                  _FakeResult_0<List<_i8.FoodiePrediction>>()))
-          as _i5.Future<_i2.Result<List<_i8.FoodiePrediction>>>);
+              returnValue: Future<_i2.Result<List<_i7.FoodiePrediction>>>.value(
+                  _FakeResult_0<List<_i7.FoodiePrediction>>()))
+          as _i4.Future<_i2.Result<List<_i7.FoodiePrediction>>>);
   @override
-  _i5.Future<_i2.Result<_i9.ShopDetail?>> searchShopDetailsByPlaceId(
+  _i4.Future<_i2.Result<_i8.ShopDetail?>> searchShopDetailsByPlaceId(
           {String? placeId}) =>
       (super.noSuchMethod(
               Invocation.method(
                   #searchShopDetailsByPlaceId, [], {#placeId: placeId}),
-              returnValue: Future<_i2.Result<_i9.ShopDetail?>>.value(
-                  _FakeResult_0<_i9.ShopDetail?>()))
-          as _i5.Future<_i2.Result<_i9.ShopDetail?>>);
+              returnValue: Future<_i2.Result<_i8.ShopDetail?>>.value(
+                  _FakeResult_0<_i8.ShopDetail?>()))
+          as _i4.Future<_i2.Result<_i8.ShopDetail?>>);
 }
 
 /// A class which mocks [ShopImageUseCase].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockShopImageUseCase extends _i1.Mock implements _i10.ShopImageUseCase {
+class MockShopImageUseCase extends _i1.Mock implements _i9.ShopImageUseCase {
   MockShopImageUseCase() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Future<_i2.Result<String?>> postImages(
+  _i4.Future<_i2.Result<String?>> postImages(
           {String? path, String? shopId, String? fileName}) =>
       (super.noSuchMethod(
               Invocation.method(#postImages, [],
                   {#path: path, #shopId: shopId, #fileName: fileName}),
               returnValue:
                   Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
-          as _i5.Future<_i2.Result<String?>>);
+          as _i4.Future<_i2.Result<String?>>);
   @override
-  _i5.Future<_i2.Result<String?>> getImagesUrl(
+  _i4.Future<_i2.Result<String?>> getImagesUrl(
           {String? path, String? shopId, String? fileName}) =>
       (super.noSuchMethod(
               Invocation.method(#getImagesUrl, [],
                   {#path: path, #shopId: shopId, #fileName: fileName}),
               returnValue:
                   Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
-          as _i5.Future<_i2.Result<String?>>);
+          as _i4.Future<_i2.Result<String?>>);
   @override
-  _i5.Future<_i2.Result<String>> deleteImages({String? shopId}) => (super
+  _i4.Future<_i2.Result<String>> deleteImages({String? shopId}) => (super
           .noSuchMethod(Invocation.method(#deleteImages, [], {#shopId: shopId}),
               returnValue:
                   Future<_i2.Result<String>>.value(_FakeResult_0<String>()))
-      as _i5.Future<_i2.Result<String>>);
+      as _i4.Future<_i2.Result<String>>);
 }
 
-/// A class which mocks [XFile].
+/// A class which mocks [ImageFileUseCase].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockXFile extends _i1.Mock implements _i3.XFile {
-  MockXFile() {
+class MockImageFileUseCase extends _i1.Mock implements _i10.ImageFileUseCase {
+  MockImageFileUseCase() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  String get path =>
-      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
+  _i4.Future<_i2.Result<List<_i11.File>>> pickMultiImage() =>
+      (super.noSuchMethod(Invocation.method(#pickMultiImage, []),
+              returnValue: Future<_i2.Result<List<_i11.File>>>.value(
+                  _FakeResult_0<List<_i11.File>>()))
+          as _i4.Future<_i2.Result<List<_i11.File>>>);
   @override
-  String get name =>
-      (super.noSuchMethod(Invocation.getter(#name), returnValue: '') as String);
-  @override
-  _i5.Future<void> saveTo(String? path) =>
-      (super.noSuchMethod(Invocation.method(#saveTo, [path]),
-          returnValue: Future<void>.value(),
-          returnValueForMissingStub: Future<void>.value()) as _i5.Future<void>);
-  @override
-  _i5.Future<int> length() =>
-      (super.noSuchMethod(Invocation.method(#length, []),
-          returnValue: Future<int>.value(0)) as _i5.Future<int>);
-  @override
-  _i5.Future<String> readAsString(
-          {_i11.Encoding? encoding = const _i11.Utf8Codec()}) =>
-      (super.noSuchMethod(
-          Invocation.method(#readAsString, [], {#encoding: encoding}),
-          returnValue: Future<String>.value('')) as _i5.Future<String>);
-  @override
-  _i5.Future<_i12.Uint8List> readAsBytes() =>
-      (super.noSuchMethod(Invocation.method(#readAsBytes, []),
-              returnValue: Future<_i12.Uint8List>.value(_i12.Uint8List(0)))
-          as _i5.Future<_i12.Uint8List>);
-  @override
-  _i5.Stream<_i12.Uint8List> openRead([int? start, int? end]) =>
-      (super.noSuchMethod(Invocation.method(#openRead, [start, end]),
-              returnValue: Stream<_i12.Uint8List>.empty())
-          as _i5.Stream<_i12.Uint8List>);
-  @override
-  _i5.Future<DateTime> lastModified() =>
-      (super.noSuchMethod(Invocation.method(#lastModified, []),
-              returnValue: Future<DateTime>.value(_FakeDateTime_1()))
-          as _i5.Future<DateTime>);
-}
-
-/// A class which mocks [ImagePicker].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockImagePicker extends _i1.Mock implements _i13.ImagePicker {
-  MockImagePicker() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  _i5.Future<_i3.PickedFile?> getImage(
-          {_i3.ImageSource? source,
-          double? maxWidth,
-          double? maxHeight,
-          int? imageQuality,
-          _i3.CameraDevice? preferredCameraDevice = _i3.CameraDevice.rear}) =>
-      (super.noSuchMethod(
-              Invocation.method(#getImage, [], {
-                #source: source,
-                #maxWidth: maxWidth,
-                #maxHeight: maxHeight,
-                #imageQuality: imageQuality,
-                #preferredCameraDevice: preferredCameraDevice
-              }),
-              returnValue: Future<_i3.PickedFile?>.value())
-          as _i5.Future<_i3.PickedFile?>);
-  @override
-  _i5.Future<List<_i3.PickedFile>?> getMultiImage(
-          {double? maxWidth, double? maxHeight, int? imageQuality}) =>
-      (super.noSuchMethod(
-              Invocation.method(#getMultiImage, [], {
-                #maxWidth: maxWidth,
-                #maxHeight: maxHeight,
-                #imageQuality: imageQuality
-              }),
-              returnValue: Future<List<_i3.PickedFile>?>.value())
-          as _i5.Future<List<_i3.PickedFile>?>);
-  @override
-  _i5.Future<_i3.PickedFile?> getVideo(
-          {_i3.ImageSource? source,
-          _i3.CameraDevice? preferredCameraDevice = _i3.CameraDevice.rear,
-          Duration? maxDuration}) =>
-      (super.noSuchMethod(
-              Invocation.method(#getVideo, [], {
-                #source: source,
-                #preferredCameraDevice: preferredCameraDevice,
-                #maxDuration: maxDuration
-              }),
-              returnValue: Future<_i3.PickedFile?>.value())
-          as _i5.Future<_i3.PickedFile?>);
-  @override
-  _i5.Future<_i3.LostData> getLostData() =>
-      (super.noSuchMethod(Invocation.method(#getLostData, []),
-              returnValue: Future<_i3.LostData>.value(_FakeLostData_2()))
-          as _i5.Future<_i3.LostData>);
-  @override
-  _i5.Future<_i3.XFile?> pickImage(
-          {_i3.ImageSource? source,
-          double? maxWidth,
-          double? maxHeight,
-          int? imageQuality,
-          _i3.CameraDevice? preferredCameraDevice = _i3.CameraDevice.rear}) =>
-      (super.noSuchMethod(
-          Invocation.method(#pickImage, [], {
-            #source: source,
-            #maxWidth: maxWidth,
-            #maxHeight: maxHeight,
-            #imageQuality: imageQuality,
-            #preferredCameraDevice: preferredCameraDevice
-          }),
-          returnValue: Future<_i3.XFile?>.value()) as _i5.Future<_i3.XFile?>);
-  @override
-  _i5.Future<List<_i3.XFile>?> pickMultiImage(
-          {double? maxWidth, double? maxHeight, int? imageQuality}) =>
-      (super.noSuchMethod(
-              Invocation.method(#pickMultiImage, [], {
-                #maxWidth: maxWidth,
-                #maxHeight: maxHeight,
-                #imageQuality: imageQuality
-              }),
-              returnValue: Future<List<_i3.XFile>?>.value())
-          as _i5.Future<List<_i3.XFile>?>);
-  @override
-  _i5.Future<_i3.XFile?> pickVideo(
-          {_i3.ImageSource? source,
-          _i3.CameraDevice? preferredCameraDevice = _i3.CameraDevice.rear,
-          Duration? maxDuration}) =>
-      (super.noSuchMethod(
-          Invocation.method(#pickVideo, [], {
-            #source: source,
-            #preferredCameraDevice: preferredCameraDevice,
-            #maxDuration: maxDuration
-          }),
-          returnValue: Future<_i3.XFile?>.value()) as _i5.Future<_i3.XFile?>);
-  @override
-  _i5.Future<_i3.LostDataResponse> retrieveLostData() =>
-      (super.noSuchMethod(Invocation.method(#retrieveLostData, []),
-              returnValue:
-                  Future<_i3.LostDataResponse>.value(_FakeLostDataResponse_3()))
-          as _i5.Future<_i3.LostDataResponse>);
+  _i4.Future<_i2.Result<_i11.File?>> pickImage() => (super.noSuchMethod(
+          Invocation.method(#pickImage, []),
+          returnValue:
+              Future<_i2.Result<_i11.File?>>.value(_FakeResult_0<_i11.File?>()))
+      as _i4.Future<_i2.Result<_i11.File?>>);
 }


### PR DESCRIPTION
- #62 の続き。
- #56 
- #50 の一部。

### 変更点
- controllerからimage pickerのインポートを削除し、XFileのstateをFileに変更
- 画像取得関数はuse caseのものを呼び出す
- 画像をタップすると画像を変更できるようになった（changeImage()）

テスト↓はまだ有効にしていないので、スルーでもOK。
- XFile -> Fileに変更した
- groupで囲っている範囲をミスしていたので修正
[test/post_shop_controller_test.dart](https://github.com/nasubibocchi/foodie_kyoto_post_app/pull/63/files#diff-34deab64c72a1374efb9f0e20ca96615d35b548f01df830584b336cf94a73f87)