### PR TITLE
お店投稿（編集）ページで画像を追加・変更できるようにする

### DIFF
--- a/lib/constants/app_colors.dart
+++ b/lib/constants/app_colors.dart
@@ -8,4 +8,5 @@ class AppColors {
   static const appActiveButtonBeige = Color(0xFFF8F0E7);
   static const appInactiveButtonBeige = Color(0xFFFFFBF8);
   static const appGrey = Color(0xFF4D4639);
+  static const appOrange = Color(0xFFF76000);
 }

--- a/lib/ui/pages/post_shop_page/image_widget.dart
+++ b/lib/ui/pages/post_shop_page/image_widget.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+class ImageWidget extends ConsumerWidget {
+  const ImageWidget({Key? key, required this.shopId}) : super(key: key);
+
+  final String shopId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = PageController(viewportFraction: 0.9);
+    final state = ref.watch(postShopProvider(shopId));
+
+    return state.when(
+      (shop, commentController, comment, images, selectedServiceTags,
+          selectedAreaTags, selectedFoodTags, postUserName) {
+        return images.isNotEmpty
+            ? Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  SizedBox(
+                    height: 350,
+                    child: PageView.builder(
+                        controller: controller,
+                        itemCount: images.length,
+                        itemBuilder: (context, int index) {
+                          return GestureDetector(
+                              onTap: () async {
+                                try {
+                                  ref
+                                      .read(postShopProvider(shopId).notifier)
+                                      .changeImage(index);
+                                } catch (e) {
+                                  await showDialog(
+                                      context: context,
+                                      builder: (context) {
+                                        return const OkDialog(
+                                            title: 'エラー',
+                                            body: '画像選択に失敗しました。もう一度試してみてください。');
+                                      });
+                                }
+                              },
+                              child: Image.file(File(images[index].path)));
+                        }),
+                  ),
+                  const SizedBox(height: 8),
+                  SmoothPageIndicator(
+                    controller: controller,
+                    count: images.length,
+                  ),
+                ],
+              )
+            : GestureDetector(
+                onTap: () async {
+                  try {
+                    ref.read(postShopProvider(shopId).notifier).selectImages();
+                  } catch (e) {
+                    await showDialog(
+                        context: context,
+                        builder: (context) {
+                          return const OkDialog(
+                              title: 'エラー', body: '画像選択に失敗しました。もう一度試してみてください。');
+                        });
+                  }
+                },
+                child: Container(
+                  height: 350,
+                  width: 350,
+                  decoration: const BoxDecoration(color: AppColors.appBeige),
+                  child: const Center(
+                    child: Text(
+                      'タップして画像を追加',
+                      style: TextStyle(color: AppColors.appBlack),
+                    ),
+                  ),
+                ),
+              );
+      },
+      loading: () => const SizedBox(),
+      error: () => const SizedBox(),
+    );
+  }
+}

--- a/lib/ui/pages/post_shop_page/image_widget.dart
+++ b/lib/ui/pages/post_shop_page/image_widget.dart
@@ -34,20 +34,31 @@ class ImageWidget extends ConsumerWidget {
                             padding: const EdgeInsets.all(4),
                             child: GestureDetector(
                                 onTap: () async {
-                                  try {
-                                    ref
-                                        .read(postShopProvider(shopId).notifier)
-                                        .changeImage(index);
-                                  } catch (e) {
-                                    await showDialog(
-                                        context: context,
-                                        builder: (context) {
-                                          return const OkDialog(
-                                              title: 'エラー',
-                                              body:
-                                                  '画像選択に失敗しました。もう一度試してみてください。');
-                                        });
-                                  }
+                                  await showDialog(
+                                      context: context,
+                                      builder: (context) {
+                                        return _ChangeOrDeleteDialog(
+                                            onTapChange: () async {
+                                              try {
+                                                ref
+                                                    .read(
+                                                        postShopProvider(shopId)
+                                                            .notifier)
+                                                    .changeImage(index);
+                                              } catch (e) {
+                                                await showDialog(
+                                                    context: context,
+                                                    builder: (context) {
+                                                      return const OkDialog(
+                                                        title: 'エラー',
+                                                        body:
+                                                            '画像選択に失敗しました。もう一度試してみてください。',
+                                                      );
+                                                    });
+                                              }
+                                            },
+                                            onTapDelete: () {});
+                                      });
                                 },
                                 child: Image.file(File(images[index].path))),
                           );
@@ -98,6 +109,51 @@ class ImageWidget extends ConsumerWidget {
       },
       loading: () => const SizedBox(),
       error: () => const SizedBox(),
+    );
+  }
+}
+
+class _ChangeOrDeleteDialog extends StatelessWidget {
+  const _ChangeOrDeleteDialog(
+      {Key? key, required this.onTapChange, required this.onTapDelete})
+      : super(key: key);
+
+  final VoidCallback onTapChange;
+  final VoidCallback onTapDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      actions: [
+        Align(
+          alignment: Alignment.topRight,
+          child: IconButton(
+              onPressed: () => Navigator.pop(context),
+              icon: const Icon(Icons.close, color: AppColors.appGrey)),
+        ),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Stack(
+              children: [
+                TextButton(
+                    onPressed: onTapChange,
+                    child: const Text(
+                      '変更',
+                      style: TextStyle(color: AppColors.appBlack, fontSize: 16),
+                    )),
+              ],
+            ),
+            const Divider(color: AppColors.appBeige, thickness: 1),
+            TextButton(
+                onPressed: onTapDelete,
+                child: const Text(
+                  '削除',
+                  style: TextStyle(color: AppColors.appBlack, fontSize: 16),
+                )),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/pages/post_shop_page/image_widget.dart
+++ b/lib/ui/pages/post_shop_page/image_widget.dart
@@ -79,6 +79,33 @@ class ImageWidget extends ConsumerWidget {
                       activeDotColor: AppColors.appOrange,
                     ),
                   ),
+                  const SizedBox(height: 16),
+                  OutlinedButton.icon(
+                      onPressed: () async {
+                        try {
+                          ref
+                              .read(postShopProvider(shopId).notifier)
+                              .selectImages();
+                        } catch (e) {
+                          await showDialog(
+                              context: context,
+                              builder: (context) {
+                                return const OkDialog(
+                                    title: 'エラー',
+                                    body: '画像選択に失敗しました。もう一度試してみてください。');
+                              });
+                        }
+                      },
+                      icon: const Icon(Icons.add,
+                          color: AppColors.appBlack, size: 16),
+                      style: OutlinedButton.styleFrom(
+                        side: const BorderSide(color: AppColors.appBlack),
+                        shape: const StadiumBorder(),
+                      ),
+                      label: const Text(
+                        '追加',
+                        style: TextStyle(color: AppColors.appBlack),
+                      )),
                 ],
               )
             : GestureDetector(

--- a/lib/ui/pages/post_shop_page/image_widget.dart
+++ b/lib/ui/pages/post_shop_page/image_widget.dart
@@ -30,29 +30,43 @@ class ImageWidget extends ConsumerWidget {
                         controller: controller,
                         itemCount: images.length,
                         itemBuilder: (context, int index) {
-                          return GestureDetector(
-                              onTap: () async {
-                                try {
-                                  ref
-                                      .read(postShopProvider(shopId).notifier)
-                                      .changeImage(index);
-                                } catch (e) {
-                                  await showDialog(
-                                      context: context,
-                                      builder: (context) {
-                                        return const OkDialog(
-                                            title: 'エラー',
-                                            body: '画像選択に失敗しました。もう一度試してみてください。');
-                                      });
-                                }
-                              },
-                              child: Image.file(File(images[index].path)));
+                          return Padding(
+                            padding: const EdgeInsets.all(4),
+                            child: GestureDetector(
+                                onTap: () async {
+                                  try {
+                                    ref
+                                        .read(postShopProvider(shopId).notifier)
+                                        .changeImage(index);
+                                  } catch (e) {
+                                    await showDialog(
+                                        context: context,
+                                        builder: (context) {
+                                          return const OkDialog(
+                                              title: 'エラー',
+                                              body:
+                                                  '画像選択に失敗しました。もう一度試してみてください。');
+                                        });
+                                  }
+                                },
+                                child: Image.file(File(images[index].path))),
+                          );
                         }),
                   ),
                   const SizedBox(height: 8),
                   SmoothPageIndicator(
                     controller: controller,
                     count: images.length,
+                    effect: const SlideEffect(
+                      spacing: 8.0,
+                      radius: 12.0,
+                      dotWidth: 12.0,
+                      dotHeight: 12.0,
+                      paintStyle: PaintingStyle.fill,
+                      strokeWidth: 1.5,
+                      dotColor: AppColors.appDarkBeige,
+                      activeDotColor: AppColors.appOrange,
+                    ),
                   ),
                 ],
               )

--- a/lib/ui/pages/post_shop_page/post_shop_page.dart
+++ b/lib/ui/pages/post_shop_page/post_shop_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
@@ -8,6 +6,7 @@ import 'package:foodie_kyoto_post_app/constants/tags_data.dart';
 import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
 import 'package:foodie_kyoto_post_app/ui/components/tag_button.dart';
 import 'package:foodie_kyoto_post_app/ui/components/user_button.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/image_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -36,61 +35,7 @@ class PostShopPage extends HookConsumerWidget {
             children: [
               Text(shop?.name ?? ''),
               const SizedBox(height: 20),
-              images.isNotEmpty
-                  ? SizedBox(
-                      height: 350,
-                      child: PageView.builder(
-                          itemCount: images.length,
-                          itemBuilder: (context, int index) {
-                            return GestureDetector(
-                                onTap: () async {
-                                  try {
-                                    ref
-                                        .read(postShopProvider(shopId).notifier)
-                                        .changeImage(index);
-                                  } catch (e) {
-                                    await showDialog(
-                                        context: context,
-                                        builder: (context) {
-                                          return const OkDialog(
-                                              title: 'エラー',
-                                              body:
-                                                  '画像選択に失敗しました。もう一度試してみてください。');
-                                        });
-                                  }
-                                },
-                                child: Image.file(File(images[index].path)));
-                          }),
-                    )
-                  : GestureDetector(
-                      onTap: () async {
-                        try {
-                          ref
-                              .read(postShopProvider(shopId).notifier)
-                              .selectImages();
-                        } catch (e) {
-                          await showDialog(
-                              context: context,
-                              builder: (context) {
-                                return const OkDialog(
-                                    title: 'エラー',
-                                    body: '画像選択に失敗しました。もう一度試してみてください。');
-                              });
-                        }
-                      },
-                      child: Container(
-                        height: 350,
-                        width: 350,
-                        decoration:
-                            const BoxDecoration(color: AppColors.appBeige),
-                        child: const Center(
-                          child: Text(
-                            'タップして画像を追加',
-                            style: TextStyle(color: AppColors.appBlack),
-                          ),
-                        ),
-                      ),
-                    ),
+              ImageWidget(shopId: shopId),
               const SizedBox(height: 20),
               TextField(
                 controller: commentController,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   # Misc
   image_picker: ^0.8.5+3
   path_provider: ^2.0.10
+  smooth_page_indicator: ^1.0.0+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- #50 
のうち、削除以外ができるようになる。

### 変更点
- 選択済みの画像をタップすると、変更or削除のダイアログが開く
- 変更をタップすると画像ライブラリが開く
- 削除を押しても反応しない（次のブランチで実装）
- 追加ボタンを実装
　→ 追加ボタンをタップすると画像ライブラリが開き、選択すると選択済み枚数がふえる
- インジケータを追加し、今見ている画像が何枚目かをわかりやすくした