### PR TITLE
編集ボタンをタップしたらお店編集（投稿）ページに移動する

### DIFF
--- a/lib/ui/pages/google_map_page/shop_information_widget.dart
+++ b/lib/ui/pages/google_map_page/shop_information_widget.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:foodie_kyoto_post_app/constants.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/shop.dart';
+import 'package:go_router/go_router.dart';
 
 class ShopInformationWidget extends StatelessWidget {
   const ShopInformationWidget(
@@ -86,7 +88,9 @@ class ShopInformationWidget extends StatelessWidget {
                       )),
                   const SizedBox(width: 8),
                   ElevatedButton.icon(
-                      onPressed: () {},
+                      onPressed: () => context.go(
+                          '/${RouteNames.searchShopPage}/${RouteNames.postShopPage}',
+                          extra: shop.shopId),
                       style: ElevatedButton.styleFrom(
                         primary: AppColors.appInactiveButtonBeige,
                       ),


### PR DESCRIPTION
- #83 

実装済み：編集ボタンタップ時に編集ページへ移動
未実装：メニュー追加ボタンを押してもまだ何も実行しない

該当ページ | 移動先
:--: | :--:
<img src="https://user-images.githubusercontent.com/87467867/171764220-389a05a6-0bbb-4295-884b-361dda2e7fb9.jpg" width="240" /> | <img src="https://user-images.githubusercontent.com/87467867/171764184-add5897b-b340-4367-9b10-9245ba5a4156.png" width="240" />

仕様：
編集ボタンをタップしたら、取得しているShop情報のIDからFirestoreを検索・情報を取得
→ 編集ページには登録情報を表示し、編集できる。

※一回取得回数が多くなるけど、実装しやすいのもありこの仕様にした。アプリ起動時に取得した情報を渡すことも可能なので、取得回数が気になるようになったら改善しても良さそう。

表示がわ（マップの上に表示しているエリア）はstreamなので、最新の情報が取得できている状態。
