### PR TITLE
【確認ページ】登録した情報を確認する詳細ページを作成

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -39,6 +39,9 @@ PODS:
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
   - Flutter (1.0.0)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
   - google_maps_flutter (0.0.1):
     - Flutter
     - GoogleMaps
@@ -70,6 +73,9 @@ PODS:
   - permission_handler_apple (9.0.4):
     - Flutter
   - PromisesObjC (2.1.0)
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -82,6 +88,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
 
 SPEC REPOS:
   trunk:
@@ -89,6 +96,7 @@ SPEC REPOS:
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseStorage
+    - FMDB
     - GoogleDataTransport
     - GoogleMaps
     - GoogleUtilities
@@ -118,6 +126,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_ios/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
 
 CHECKOUT OPTIONS:
   FirebaseFirestore:
@@ -134,6 +144,7 @@ SPEC CHECKSUMS:
   FirebaseFirestore: cb361b7f8f225a225c9f11b8d42066baebb1630c
   FirebaseStorage: 8019af461599b2c3bc61c6a5dbdfa3d2de66a4d9
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   google_maps_flutter: c59fc576c0d0c7f4dc4bd63832c862d22d5a7c6d
   GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
   GoogleMaps: 025272d5876d3b32604e5c080dc25eaf68764693
@@ -145,6 +156,7 @@ SPEC CHECKSUMS:
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
 
 PODFILE CHECKSUM: b83d54518ddb4d568ebaae31cf4f2b31bb2e695d
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -6,4 +6,5 @@ class RouteNames {
   static const String searchShopPage = 'search_shop_page';
   static const String postShopPage = 'post_shop_page';
   static const String postMenuPage = 'post_menu_page';
+  static const String shopDetailPage = 'shop_detail_page';
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:foodie_kyoto_post_app/constants.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/shop.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/google_map_page/google_map_page.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_page.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_page.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/search_shop_page/search_shop_page.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/shop_detail_page/shop_detail_page.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -25,9 +27,26 @@ final routerProvider = Provider<GoRouter>((ref) => GoRouter(routes: <GoRoute>[
                   ),
                 ]),
             GoRoute(
+              path: RouteNames.postShopPage,
+              pageBuilder: (context, state) => MaterialPage(
+                  child: PostShopPage(shopId: state.extra as String)),
+            ),
+            GoRoute(
               path: RouteNames.postMenuPage,
               pageBuilder: (context, state) => MaterialPage(
                   child: PostMenuPage(shopId: state.extra as String)),
+            ),
+            GoRoute(
+              path: RouteNames.shopDetailPage,
+              pageBuilder: (context, state) => MaterialPage(
+                  child: ShopDetailPage(shop: state.extra as Shop)),
+              routes: [
+                GoRoute(
+                  path: RouteNames.postMenuPage,
+                  pageBuilder: (context, state) => MaterialPage(
+                      child: PostMenuPage(shopId: state.extra as String)),
+                ),
+              ],
             ),
           ]),
     ]));

--- a/lib/ui/pages/google_map_page/shop_information_widget.dart
+++ b/lib/ui/pages/google_map_page/shop_information_widget.dart
@@ -17,95 +17,100 @@ class ShopInformationWidget extends StatelessWidget {
     return SizedBox(
       height: 360,
       width: 400,
-      child: Card(
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            children: [
-              Align(
-                alignment: Alignment.topRight,
-                child: GestureDetector(
-                  onTap: onTapClose,
-                  child: const Icon(Icons.close, color: AppColors.appBlack),
+      child: GestureDetector(
+        onTap: () {
+          context.go('/${RouteNames.shopDetailPage}', extra: shop);
+        },
+        child: Card(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Align(
+                  alignment: Alignment.topRight,
+                  child: GestureDetector(
+                    onTap: onTapClose,
+                    child: const Icon(Icons.close, color: AppColors.appBlack),
+                  ),
                 ),
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SizedBox(
-                    height: 120,
-                    child: ListView.builder(
-                        scrollDirection: Axis.horizontal,
-                        itemCount: shop.images.length,
-                        itemBuilder: (context, int index) {
-                          return Padding(
-                            padding: const EdgeInsets.all(4),
-                            child:
-                                Image(image: NetworkImage(shop.images[index])),
-                          );
-                        }),
-                  ),
-                  const SizedBox(height: 16),
-                  FittedBox(
-                    child: Text(
-                      shop.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.fade,
-                      style: const TextStyle(
-                          color: AppColors.appBlack, fontSize: 24),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(
+                      height: 120,
+                      child: ListView.builder(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: shop.images.length,
+                          itemBuilder: (context, int index) {
+                            return Padding(
+                              padding: const EdgeInsets.all(4),
+                              child: Image(
+                                  image: NetworkImage(shop.images[index])),
+                            );
+                          }),
                     ),
-                  ),
-                  const SizedBox(height: 16),
-                  FittedBox(
-                    child: Text(
-                      shop.comment,
-                      maxLines: 2,
-                      overflow: TextOverflow.fade,
-                      style: const TextStyle(
-                          color: AppColors.appBlack, fontSize: 16),
+                    const SizedBox(height: 16),
+                    FittedBox(
+                      child: Text(
+                        shop.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.fade,
+                        style: const TextStyle(
+                            color: AppColors.appBlack, fontSize: 24),
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  ElevatedButton.icon(
-                      onPressed: () {
-                        context.go('/${RouteNames.postMenuPage}',
-                            extra: shop.shopId);
-                      },
-                      style: ElevatedButton.styleFrom(
-                        primary: AppColors.appInactiveButtonBeige,
+                    const SizedBox(height: 16),
+                    FittedBox(
+                      child: Text(
+                        shop.comment,
+                        maxLines: 2,
+                        overflow: TextOverflow.fade,
+                        style: const TextStyle(
+                            color: AppColors.appBlack, fontSize: 16),
                       ),
-                      icon: const Icon(Icons.add_circle_outline,
-                          color: AppColors.appGrey),
-                      label: const Text(
-                        'メニューを追加',
-                        style:
-                            TextStyle(color: AppColors.appGrey, fontSize: 16),
-                      )),
-                  const SizedBox(width: 8),
-                  ElevatedButton.icon(
-                      onPressed: () => context.go(
-                          '/${RouteNames.searchShopPage}/${RouteNames.postShopPage}',
-                          extra: shop.shopId),
-                      style: ElevatedButton.styleFrom(
-                        primary: AppColors.appInactiveButtonBeige,
-                      ),
-                      icon: const Icon(Icons.edit, color: AppColors.appGrey),
-                      label: const Text(
-                        '編集',
-                        style:
-                            TextStyle(color: AppColors.appGrey, fontSize: 16),
-                      )),
-                ],
-              ),
-            ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ElevatedButton.icon(
+                        onPressed: () {
+                          context.go('/${RouteNames.postMenuPage}',
+                              extra: shop.shopId);
+                        },
+                        style: ElevatedButton.styleFrom(
+                          primary: AppColors.appInactiveButtonBeige,
+                        ),
+                        icon: const Icon(Icons.add_circle_outline,
+                            color: AppColors.appGrey),
+                        label: const Text(
+                          'メニューを追加',
+                          style:
+                              TextStyle(color: AppColors.appGrey, fontSize: 16),
+                        )),
+                    const SizedBox(width: 8),
+                    ElevatedButton.icon(
+                        onPressed: () => context.go(
+                            '/${RouteNames.postShopPage}',
+                            extra: shop.shopId),
+                        style: ElevatedButton.styleFrom(
+                          primary: AppColors.appInactiveButtonBeige,
+                        ),
+                        icon: const Icon(Icons.edit, color: AppColors.appGrey),
+                        label: const Text(
+                          '編集',
+                          style:
+                              TextStyle(color: AppColors.appGrey, fontSize: 16),
+                        )),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/pages/shop_detail_page/shop_detail_controller.dart
+++ b/lib/ui/pages/shop_detail_page/shop_detail_controller.dart
@@ -1,0 +1,37 @@
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+part 'shop_detail_controller.freezed.dart';
+
+@freezed
+class ShopDetailState with _$ShopDetailState {
+  factory ShopDetailState({required List<Menu> menu}) = _ShopDetailState;
+
+  factory ShopDetailState.loading() = _ShopDetailStateLoading;
+
+  factory ShopDetailState.error() = _ShopDetailStateError;
+}
+
+class ShopDetailController extends StateNotifier<ShopDetailState> {
+  ShopDetailController(this._menuUseCase, this._shopId)
+      : super(ShopDetailState.loading()) {
+    fetchShopMenus();
+  }
+
+  final MenuUseCase _menuUseCase;
+  final String _shopId;
+
+  Future<void> fetchShopMenus() async {
+    final menuResult = await _menuUseCase.fetchShopMenus(shopId: _shopId);
+
+    menuResult.whenWithResult(
+      (success) {
+        final menu = success.value;
+        state = ShopDetailState(menu: menu);
+      },
+      (e) => state = ShopDetailState.error(),
+    );
+  }
+}

--- a/lib/ui/pages/shop_detail_page/shop_detail_controller.freezed.dart
+++ b/lib/ui/pages/shop_detail_page/shop_detail_controller.freezed.dart
@@ -1,0 +1,449 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'shop_detail_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ShopDetailState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<Menu> menu) $default, {
+    required TResult Function() loading,
+    required TResult Function() error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ShopDetailState value) $default, {
+    required TResult Function(_ShopDetailStateLoading value) loading,
+    required TResult Function(_ShopDetailStateError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ShopDetailStateCopyWith<$Res> {
+  factory $ShopDetailStateCopyWith(
+          ShopDetailState value, $Res Function(ShopDetailState) then) =
+      _$ShopDetailStateCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$ShopDetailStateCopyWithImpl<$Res>
+    implements $ShopDetailStateCopyWith<$Res> {
+  _$ShopDetailStateCopyWithImpl(this._value, this._then);
+
+  final ShopDetailState _value;
+  // ignore: unused_field
+  final $Res Function(ShopDetailState) _then;
+}
+
+/// @nodoc
+abstract class _$$_ShopDetailStateCopyWith<$Res> {
+  factory _$$_ShopDetailStateCopyWith(
+          _$_ShopDetailState value, $Res Function(_$_ShopDetailState) then) =
+      __$$_ShopDetailStateCopyWithImpl<$Res>;
+  $Res call({List<Menu> menu});
+}
+
+/// @nodoc
+class __$$_ShopDetailStateCopyWithImpl<$Res>
+    extends _$ShopDetailStateCopyWithImpl<$Res>
+    implements _$$_ShopDetailStateCopyWith<$Res> {
+  __$$_ShopDetailStateCopyWithImpl(
+      _$_ShopDetailState _value, $Res Function(_$_ShopDetailState) _then)
+      : super(_value, (v) => _then(v as _$_ShopDetailState));
+
+  @override
+  _$_ShopDetailState get _value => super._value as _$_ShopDetailState;
+
+  @override
+  $Res call({
+    Object? menu = freezed,
+  }) {
+    return _then(_$_ShopDetailState(
+      menu: menu == freezed
+          ? _value._menu
+          : menu // ignore: cast_nullable_to_non_nullable
+              as List<Menu>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ShopDetailState implements _ShopDetailState {
+  _$_ShopDetailState({required final List<Menu> menu}) : _menu = menu;
+
+  final List<Menu> _menu;
+  @override
+  List<Menu> get menu {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_menu);
+  }
+
+  @override
+  String toString() {
+    return 'ShopDetailState(menu: $menu)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ShopDetailState &&
+            const DeepCollectionEquality().equals(other._menu, _menu));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_menu));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ShopDetailStateCopyWith<_$_ShopDetailState> get copyWith =>
+      __$$_ShopDetailStateCopyWithImpl<_$_ShopDetailState>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<Menu> menu) $default, {
+    required TResult Function() loading,
+    required TResult Function() error,
+  }) {
+    return $default(menu);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+  }) {
+    return $default?.call(menu);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(menu);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ShopDetailState value) $default, {
+    required TResult Function(_ShopDetailStateLoading value) loading,
+    required TResult Function(_ShopDetailStateError value) error,
+  }) {
+    return $default(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+  }) {
+    return $default?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ShopDetailState implements ShopDetailState {
+  factory _ShopDetailState({required final List<Menu> menu}) =
+      _$_ShopDetailState;
+
+  List<Menu> get menu => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  _$$_ShopDetailStateCopyWith<_$_ShopDetailState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_ShopDetailStateLoadingCopyWith<$Res> {
+  factory _$$_ShopDetailStateLoadingCopyWith(_$_ShopDetailStateLoading value,
+          $Res Function(_$_ShopDetailStateLoading) then) =
+      __$$_ShopDetailStateLoadingCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$_ShopDetailStateLoadingCopyWithImpl<$Res>
+    extends _$ShopDetailStateCopyWithImpl<$Res>
+    implements _$$_ShopDetailStateLoadingCopyWith<$Res> {
+  __$$_ShopDetailStateLoadingCopyWithImpl(_$_ShopDetailStateLoading _value,
+      $Res Function(_$_ShopDetailStateLoading) _then)
+      : super(_value, (v) => _then(v as _$_ShopDetailStateLoading));
+
+  @override
+  _$_ShopDetailStateLoading get _value =>
+      super._value as _$_ShopDetailStateLoading;
+}
+
+/// @nodoc
+
+class _$_ShopDetailStateLoading implements _ShopDetailStateLoading {
+  _$_ShopDetailStateLoading();
+
+  @override
+  String toString() {
+    return 'ShopDetailState.loading()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ShopDetailStateLoading);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<Menu> menu) $default, {
+    required TResult Function() loading,
+    required TResult Function() error,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ShopDetailState value) $default, {
+    required TResult Function(_ShopDetailStateLoading value) loading,
+    required TResult Function(_ShopDetailStateError value) error,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ShopDetailStateLoading implements ShopDetailState {
+  factory _ShopDetailStateLoading() = _$_ShopDetailStateLoading;
+}
+
+/// @nodoc
+abstract class _$$_ShopDetailStateErrorCopyWith<$Res> {
+  factory _$$_ShopDetailStateErrorCopyWith(_$_ShopDetailStateError value,
+          $Res Function(_$_ShopDetailStateError) then) =
+      __$$_ShopDetailStateErrorCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$_ShopDetailStateErrorCopyWithImpl<$Res>
+    extends _$ShopDetailStateCopyWithImpl<$Res>
+    implements _$$_ShopDetailStateErrorCopyWith<$Res> {
+  __$$_ShopDetailStateErrorCopyWithImpl(_$_ShopDetailStateError _value,
+      $Res Function(_$_ShopDetailStateError) _then)
+      : super(_value, (v) => _then(v as _$_ShopDetailStateError));
+
+  @override
+  _$_ShopDetailStateError get _value => super._value as _$_ShopDetailStateError;
+}
+
+/// @nodoc
+
+class _$_ShopDetailStateError implements _ShopDetailStateError {
+  _$_ShopDetailStateError();
+
+  @override
+  String toString() {
+    return 'ShopDetailState.error()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$_ShopDetailStateError);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<Menu> menu) $default, {
+    required TResult Function() loading,
+    required TResult Function() error,
+  }) {
+    return error();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+  }) {
+    return error?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<Menu> menu)? $default, {
+    TResult Function()? loading,
+    TResult Function()? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ShopDetailState value) $default, {
+    required TResult Function(_ShopDetailStateLoading value) loading,
+    required TResult Function(_ShopDetailStateError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ShopDetailState value)? $default, {
+    TResult Function(_ShopDetailStateLoading value)? loading,
+    TResult Function(_ShopDetailStateError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ShopDetailStateError implements ShopDetailState {
+  factory _ShopDetailStateError() = _$_ShopDetailStateError;
+}

--- a/lib/ui/pages/shop_detail_page/shop_detail_page.dart
+++ b/lib/ui/pages/shop_detail_page/shop_detail_page.dart
@@ -1,0 +1,366 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:foodie_kyoto_post_app/constants.dart';
+import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/constants/tags_data.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/shop.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/shop_detail_page/shop_detail_provider.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+class ShopDetailPage extends HookConsumerWidget {
+  const ShopDetailPage({Key? key, required this.shop}) : super(key: key);
+
+  final Shop shop;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(shopDetailProvider(shop.shopId));
+    final _shopImageController =
+        PageController(initialPage: 0, viewportFraction: 0.9);
+
+    final serviceTags =
+        shop.serviceTags.map((key) => ServiceTags.serviceTags[key]).toList();
+    final areaTags =
+        shop.areaTags.map((key) => AreaTags.areaTags[key]).toList();
+    final foodTags =
+        shop.foodTags.map((key) => FoodTags.foodTags[key]).toList();
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        iconTheme: const IconThemeData(color: AppColors.appBlack),
+        title: Text(
+          shop.name,
+          style: const TextStyle(color: AppColors.appBlack),
+        ),
+      ),
+      body: state.when(
+        (menu) {
+          return CustomScrollView(
+            slivers: [
+              SliverList(
+                delegate: SliverChildListDelegate([
+                  const Divider(
+                    thickness: 4,
+                    color: AppColors.appDarkBeige,
+                    indent: 0,
+                    endIndent: 0,
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        height: 350,
+                        child: PageView.builder(
+                            itemCount: shop.images.length,
+                            scrollDirection: Axis.horizontal,
+                            controller: _shopImageController,
+                            itemBuilder: (context, int index) {
+                              return Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: CachedNetworkImage(
+                                    imageUrl: shop.images[index]),
+                              );
+                            }),
+                      ),
+                      const SizedBox(height: 8),
+                      SmoothPageIndicator(
+                        controller: _shopImageController,
+                        count: shop.images.length,
+                        effect: const SlideEffect(
+                          spacing: 8.0,
+                          radius: 12.0,
+                          dotWidth: 12.0,
+                          dotHeight: 12.0,
+                          paintStyle: PaintingStyle.fill,
+                          strokeWidth: 1.5,
+                          dotColor: AppColors.appDarkBeige,
+                          activeDotColor: AppColors.appOrange,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                  ),
+                  const Divider(
+                    thickness: 4,
+                    color: AppColors.appDarkBeige,
+                    indent: 0,
+                    endIndent: 0,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'レビュー（${shop.postUser}）',
+                          style: const TextStyle(
+                              color: AppColors.appBlack, fontSize: 16),
+                        ),
+                        const SizedBox(height: 8),
+                        SizedBox(
+                          width: double.infinity,
+                          child: Text(
+                            shop.comment,
+                            maxLines: 10,
+                            style: const TextStyle(
+                                color: AppColors.appBlack, fontSize: 14),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                      ],
+                    ),
+                  ),
+                  const Divider(
+                    thickness: 4,
+                    color: AppColors.appDarkBeige,
+                    indent: 0,
+                    endIndent: 0,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          '予算',
+                          style: TextStyle(
+                              color: AppColors.appBlack, fontSize: 16),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            Text(
+                              '¥${shop.price}',
+                              style: const TextStyle(
+                                  color: AppColors.appBlack, fontSize: 14),
+                            ),
+                            const SizedBox(width: 2),
+                            const Text(
+                              '円',
+                              style: TextStyle(
+                                  color: AppColors.appBlack, fontSize: 12),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Divider(
+                    thickness: 4,
+                    color: AppColors.appDarkBeige,
+                    indent: 0,
+                    endIndent: 0,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          '選択したタグ',
+                          style: TextStyle(
+                              color: AppColors.appBlack, fontSize: 16),
+                        ),
+                        const SizedBox(height: 8),
+                        Wrap(
+                            children: (serviceTags + areaTags + foodTags)
+                                .map((e) => _TagWidget(tagName: e))
+                                .toList()),
+                      ],
+                    ),
+                  ),
+                  const Divider(
+                    thickness: 4,
+                    color: AppColors.appDarkBeige,
+                    indent: 0,
+                    endIndent: 0,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Stack(
+                          children: [
+                            const Text(
+                              'menu',
+                              style: TextStyle(
+                                  color: AppColors.appBlack, fontSize: 16),
+                            ),
+                            Align(
+                              alignment: Alignment.topRight,
+                              child: GestureDetector(
+                                onTap: () {
+                                  context.go(
+                                    '/${RouteNames.shopDetailPage}/${RouteNames.postMenuPage}',
+                                    extra: shop.shopId,
+                                  );
+                                },
+                                child: const Icon(
+                                  Icons.add_circle_outline,
+                                  color: AppColors.appGrey,
+                                  size: 24,
+                                ),
+                              ),
+                            )
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        menu.isNotEmpty
+                            ? ListView.builder(
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: menu.length,
+                                itemBuilder: (context, int index) {
+                                  return _MenuWidget(menu: menu[index]);
+                                })
+                            : const Text(
+                                'メニューを追加しましょう',
+                                style: TextStyle(color: AppColors.appBlack),
+                              ),
+                        const SizedBox(height: 8),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                ]),
+              ),
+            ],
+          );
+        },
+        loading: () {
+          return const Center(
+            child: CircularProgressIndicator(color: AppColors.appGrey),
+          );
+        },
+        error: () {
+          return const Center(
+            child: CircularProgressIndicator(color: AppColors.appGrey),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _TagWidget extends StatelessWidget {
+  const _TagWidget({Key? key, required this.tagName}) : super(key: key);
+
+  final String? tagName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+          color: AppColors.appInactiveButtonBeige,
+          borderRadius: BorderRadius.circular(8),
+          boxShadow: (const [
+            BoxShadow(offset: Offset(0, 2), color: Colors.grey, blurRadius: 2)
+          ])),
+      padding: const EdgeInsets.all(8),
+      margin: const EdgeInsets.all(8),
+      child: tagName != null
+          ? Text(
+              tagName!,
+              style: const TextStyle(color: AppColors.appBlack, fontSize: 14),
+            )
+          : const SizedBox(),
+    );
+  }
+}
+
+class _MenuWidget extends StatelessWidget {
+  const _MenuWidget({Key? key, required this.menu}) : super(key: key);
+
+  final Menu menu;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+      child: Container(
+          height: 96,
+          width: double.infinity,
+          decoration: const BoxDecoration(
+            color: AppColors.appInactiveButtonBeige,
+            boxShadow: [BoxShadow()],
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              SizedBox(
+                height: 96,
+                width: 96,
+                child: CachedNetworkImage(imageUrl: menu.images.first),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Stack(
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.baseline,
+                          textBaseline: TextBaseline.alphabetic,
+                          children: [
+                            Text(
+                              menu.name,
+                              style: const TextStyle(
+                                  color: AppColors.appBlack,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              '¥${menu.price}',
+                              style: const TextStyle(
+                                  color: AppColors.appBlack, fontSize: 12),
+                            ),
+                          ],
+                        ),
+                        Text(
+                          menu.postUser,
+                          style: const TextStyle(
+                              color: AppColors.appBlack, fontSize: 12),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 8, horizontal: 0),
+                          child: Text(
+                            menu.review,
+                            maxLines: 3,
+                            style: const TextStyle(
+                                color: AppColors.appBlack, fontSize: 12),
+                          ),
+                        )
+                      ],
+                    ),
+                    Align(
+                      alignment: Alignment.topRight,
+                      child: GestureDetector(
+                        onTap: () {
+                          // メニュー編集ページへ移動
+                        },
+                        child: const Icon(
+                          Icons.edit_rounded,
+                          color: AppColors.appGrey,
+                          size: 24,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          )),
+    );
+  }
+}

--- a/lib/ui/pages/shop_detail_page/shop_detail_provider.dart
+++ b/lib/ui/pages/shop_detail_page/shop_detail_provider.dart
@@ -1,0 +1,8 @@
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/shop_detail_page/shop_detail_controller.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final shopDetailProvider =
+    StateNotifierProvider.family<ShopDetailController, ShopDetailState, String>(
+        (ref, _shopId) =>
+            ShopDetailController(ref.read(menuUseCaseProvider), _shopId));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,6 +92,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.3.2"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   characters:
     dependency: transitive
     description:
@@ -279,6 +300,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.3.0"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -541,6 +576,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.2.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   package_config:
     dependency: transitive
     description:
@@ -646,6 +688,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.7"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   permission_handler:
     dependency: "direct main"
     description:
@@ -791,6 +840,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2+1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -826,6 +889,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0+2"
   term_glyph:
     dependency: transitive
     description:
@@ -854,6 +924,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.6"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   image_picker: ^0.8.5+3
   path_provider: ^2.0.10
   smooth_page_indicator: ^1.0.0+2
+  cached_network_image: ^3.2.1
 
 dev_dependencies:
   flutter_test:

--- a/test/post_menu_controller_test.mocks.dart
+++ b/test/post_menu_controller_test.mocks.dart
@@ -36,4 +36,11 @@ class MockMenuUseCase extends _i1.Mock implements _i3.MenuUseCase {
               returnValue:
                   Future<_i2.Result<_i5.Menu>>.value(_FakeResult_0<_i5.Menu>()))
           as _i4.Future<_i2.Result<_i5.Menu>>);
+  @override
+  _i4.Future<_i2.Result<List<_i5.Menu>>> fetchShopMenus({String? shopId}) =>
+      (super.noSuchMethod(
+              Invocation.method(#fetchShopMenus, [], {#shopId: shopId}),
+              returnValue: Future<_i2.Result<List<_i5.Menu>>>.value(
+                  _FakeResult_0<List<_i5.Menu>>()))
+          as _i4.Future<_i2.Result<List<_i5.Menu>>>);
 }


### PR DESCRIPTION
- #108 

### 実装済み
- マップページから詳細ページへの遷移
- お店情報の表示（デバッグ済み）
- メニュー新規作成ページへの遷移

### 未確認
- メニューの表示（メニューをまだ登録できないので、未確認）
- メニューの修正ページへの遷移

デフォルト | ちょっとスクロール
:--: | :--:
<img src="https://user-images.githubusercontent.com/87467867/172102564-20d8fa63-371c-45bf-a497-5f19a4567c93.PNG" width="240" /> | <img src="https://user-images.githubusercontent.com/87467867/172102554-eb966670-b438-4569-8038-33110a02a668.PNG" width="240" />
