### PR TITLE
【menu登録機能】画像を選択できるようにする

### DIFF
--- a/lib/ui/components/change_or_delete_dialog.dart
+++ b/lib/ui/components/change_or_delete_dialog.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+
+class ChangeOrDeleteDialog extends StatelessWidget {
+  const ChangeOrDeleteDialog(
+      {Key? key, required this.onTapChange, required this.onTapDelete})
+      : super(key: key);
+
+  final VoidCallback onTapChange;
+  final VoidCallback onTapDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      actions: [
+        Align(
+          alignment: Alignment.topRight,
+          child: IconButton(
+              onPressed: () => Navigator.pop(context),
+              icon: const Icon(Icons.close, color: AppColors.appGrey)),
+        ),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Stack(
+              children: [
+                TextButton(
+                    onPressed: onTapChange,
+                    child: const Text(
+                      '変更',
+                      style: TextStyle(color: AppColors.appBlack, fontSize: 16),
+                    )),
+              ],
+            ),
+            const Divider(color: AppColors.appBeige, thickness: 1),
+            TextButton(
+                onPressed: onTapDelete,
+                child: const Text(
+                  '削除',
+                  style: TextStyle(color: AppColors.appBlack, fontSize: 16),
+                )),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/post_menu_page/menu_image_widget.dart
+++ b/lib/ui/pages/post_menu_page/menu_image_widget.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/ui/components/change_or_delete_dialog.dart';
+import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+class MenuImageWidget extends ConsumerWidget {
+  const MenuImageWidget({Key? key, required this.shopId}) : super(key: key);
+
+  final String shopId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final images = ref.watch(postMenuProvider(shopId).select((s) => s.images));
+    final controller = PageController(viewportFraction: 0.9);
+
+    return images.isNotEmpty
+        ? Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                height: 350,
+                child: PageView.builder(
+                    controller: controller,
+                    itemCount: images.length,
+                    itemBuilder: (context, int index) {
+                      return Padding(
+                        padding: const EdgeInsets.all(4),
+                        child: GestureDetector(
+                            onTap: () async {
+                              await showDialog(
+                                  context: context,
+                                  builder: (context) {
+                                    return ChangeOrDeleteDialog(
+                                        onTapChange: () async {
+                                      try {
+                                        ref
+                                            .read(postMenuProvider(shopId)
+                                                .notifier)
+                                            .changeImage(index);
+                                      } catch (e) {
+                                        await showDialog(
+                                            context: context,
+                                            builder: (context) {
+                                              return const OkDialog(
+                                                title: 'エラー',
+                                                body:
+                                                    '画像選択に失敗しました。もう一度試してみてください。',
+                                              );
+                                            });
+                                      }
+                                    }, onTapDelete: () {
+                                      ref
+                                          .read(
+                                              postMenuProvider(shopId).notifier)
+                                          .deleteSelectedImage(index);
+                                    });
+                                  });
+                            },
+                            child: Image.file(File(images[index].path))),
+                      );
+                    }),
+              ),
+              const SizedBox(height: 8),
+              SmoothPageIndicator(
+                controller: controller,
+                count: images.length,
+                effect: const SlideEffect(
+                  spacing: 8.0,
+                  radius: 12.0,
+                  dotWidth: 12.0,
+                  dotHeight: 12.0,
+                  paintStyle: PaintingStyle.fill,
+                  strokeWidth: 1.5,
+                  dotColor: AppColors.appDarkBeige,
+                  activeDotColor: AppColors.appOrange,
+                ),
+              ),
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                  onPressed: () async {
+                    try {
+                      ref
+                          .read(postMenuProvider(shopId).notifier)
+                          .selectImages();
+                    } catch (e) {
+                      await showDialog(
+                          context: context,
+                          builder: (context) {
+                            return const OkDialog(
+                                title: 'エラー',
+                                body: '画像選択に失敗しました。もう一度試してみてください。');
+                          });
+                    }
+                  },
+                  icon: const Icon(Icons.add,
+                      color: AppColors.appBlack, size: 16),
+                  style: OutlinedButton.styleFrom(
+                    side: const BorderSide(color: AppColors.appBlack),
+                    shape: const StadiumBorder(),
+                  ),
+                  label: const Text(
+                    '追加',
+                    style: TextStyle(color: AppColors.appBlack),
+                  )),
+            ],
+          )
+        : GestureDetector(
+            onTap: () async {
+              try {
+                ref.read(postMenuProvider(shopId).notifier).selectImages();
+              } catch (e) {
+                await showDialog(
+                    context: context,
+                    builder: (context) {
+                      return const OkDialog(
+                          title: 'エラー', body: '画像選択に失敗しました。もう一度試してみてください。');
+                    });
+              }
+            },
+            child: Container(
+              height: 350,
+              width: 350,
+              decoration: const BoxDecoration(color: AppColors.appBeige),
+              child: const Center(
+                child: Text(
+                  'タップして画像を追加',
+                  style: TextStyle(color: AppColors.appBlack),
+                ),
+              ),
+            ),
+          );
+  }
+}

--- a/lib/ui/pages/post_menu_page/post_menu_page.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_image_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -37,6 +38,13 @@ class PostMenuPage extends HookConsumerWidget {
       body: SingleChildScrollView(
         child: Column(
           children: [
+            const Divider(
+              thickness: 4,
+              color: AppColors.appDarkBeige,
+              indent: 0,
+              endIndent: 0,
+            ),
+            MenuImageWidget(shopId: shopId),
             const Divider(
               thickness: 4,
               color: AppColors.appDarkBeige,

--- a/lib/ui/pages/post_menu_page/post_menu_provider.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_provider.dart
@@ -1,8 +1,13 @@
+import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final postMenuProvider =
     StateNotifierProvider.family<PostMenuController, PostMenuState, String>(
-        (ref, shopId) =>
-            PostMenuController(ref.read(menuUseCaseProvider), shopId));
+        (ref, shopId) => PostMenuController(
+            ref.read(menuUseCaseProvider),
+            ref.read(menuImageUseCaseProvider),
+            ref.read(imageFileUseCaseProvider),
+            shopId));

--- a/lib/ui/pages/post_shop_page/image_widget.dart
+++ b/lib/ui/pages/post_shop_page/image_widget.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/ui/components/change_or_delete_dialog.dart';
 import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -37,7 +38,7 @@ class ImageWidget extends ConsumerWidget {
                                   await showDialog(
                                       context: context,
                                       builder: (context) {
-                                        return _ChangeOrDeleteDialog(
+                                        return ChangeOrDeleteDialog(
                                             onTapChange: () async {
                                           try {
                                             ref
@@ -139,51 +140,6 @@ class ImageWidget extends ConsumerWidget {
       },
       loading: () => const SizedBox(),
       error: () => const SizedBox(),
-    );
-  }
-}
-
-class _ChangeOrDeleteDialog extends StatelessWidget {
-  const _ChangeOrDeleteDialog(
-      {Key? key, required this.onTapChange, required this.onTapDelete})
-      : super(key: key);
-
-  final VoidCallback onTapChange;
-  final VoidCallback onTapDelete;
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      actions: [
-        Align(
-          alignment: Alignment.topRight,
-          child: IconButton(
-              onPressed: () => Navigator.pop(context),
-              icon: const Icon(Icons.close, color: AppColors.appGrey)),
-        ),
-        Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Stack(
-              children: [
-                TextButton(
-                    onPressed: onTapChange,
-                    child: const Text(
-                      '変更',
-                      style: TextStyle(color: AppColors.appBlack, fontSize: 16),
-                    )),
-              ],
-            ),
-            const Divider(color: AppColors.appBeige, thickness: 1),
-            TextButton(
-                onPressed: onTapDelete,
-                child: const Text(
-                  '削除',
-                  style: TextStyle(color: AppColors.appBlack, fontSize: 16),
-                )),
-          ],
-        ),
-      ],
     );
   }
 }

--- a/test/post_menu_controller_test.dart
+++ b/test/post_menu_controller_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
@@ -8,13 +10,17 @@ import 'package:mockito/annotations.dart';
 
 import 'post_menu_controller_test.mocks.dart';
 
-@GenerateMocks([MenuUseCase])
+@GenerateMocks([MenuUseCase, MenuImageUseCase, ImageFileUseCase])
 void main() {
   final _menuUseCase = MockMenuUseCase();
+  final _menuImageUseCase = MockMenuImageUseCase();
+  final _imageFileUseCase = MockImageFileUseCase();
+
   final container = ProviderContainer(overrides: [
     postMenuProvider.overrideWithProvider(
         StateNotifierProvider.family<PostMenuController, PostMenuState, String>(
-            (ref, _shopId) => PostMenuController(_menuUseCase, _shopId))),
+            (ref, _shopId) => PostMenuController(
+                _menuUseCase, _menuImageUseCase, _imageFileUseCase, _shopId))),
   ]);
 
   group('onEditMenuName', () {

--- a/test/post_menu_controller_test.mocks.dart
+++ b/test/post_menu_controller_test.mocks.dart
@@ -3,9 +3,14 @@
 // Do not manually edit this file.
 
 import 'dart:async' as _i4;
+import 'dart:io' as _i8;
 
 import 'package:foodie_kyoto_post_app/data/model/result.dart' as _i2;
 import 'package:foodie_kyoto_post_app/domain/entity/menu.dart' as _i5;
+import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart'
+    as _i7;
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart'
+    as _i6;
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart'
     as _i3;
 import 'package:mockito/mockito.dart' as _i1;
@@ -43,4 +48,71 @@ class MockMenuUseCase extends _i1.Mock implements _i3.MenuUseCase {
               returnValue: Future<_i2.Result<List<_i5.Menu>>>.value(
                   _FakeResult_0<List<_i5.Menu>>()))
           as _i4.Future<_i2.Result<List<_i5.Menu>>>);
+}
+
+/// A class which mocks [MenuImageUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockMenuImageUseCase extends _i1.Mock implements _i6.MenuImageUseCase {
+  MockMenuImageUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i4.Future<_i2.Result<String?>> postImages(
+          {String? path, String? shopId, String? menuName, String? fileName}) =>
+      (super.noSuchMethod(
+              Invocation.method(#postImages, [], {
+                #path: path,
+                #shopId: shopId,
+                #menuName: menuName,
+                #fileName: fileName
+              }),
+              returnValue:
+                  Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
+          as _i4.Future<_i2.Result<String?>>);
+  @override
+  _i4.Future<_i2.Result<String?>> getImagesUrl(
+          {String? path, String? shopId, String? menuName, String? fileName}) =>
+      (super.noSuchMethod(
+              Invocation.method(#getImagesUrl, [], {
+                #path: path,
+                #shopId: shopId,
+                #menuName: menuName,
+                #fileName: fileName
+              }),
+              returnValue:
+                  Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
+          as _i4.Future<_i2.Result<String?>>);
+  @override
+  _i4.Future<_i2.Result<String>> deleteImages(
+          {String? shopId, String? menuName}) =>
+      (super.noSuchMethod(
+              Invocation.method(
+                  #deleteImages, [], {#shopId: shopId, #menuName: menuName}),
+              returnValue:
+                  Future<_i2.Result<String>>.value(_FakeResult_0<String>()))
+          as _i4.Future<_i2.Result<String>>);
+}
+
+/// A class which mocks [ImageFileUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockImageFileUseCase extends _i1.Mock implements _i7.ImageFileUseCase {
+  MockImageFileUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i4.Future<_i2.Result<List<_i8.File>>> pickMultiImage() =>
+      (super.noSuchMethod(Invocation.method(#pickMultiImage, []),
+              returnValue: Future<_i2.Result<List<_i8.File>>>.value(
+                  _FakeResult_0<List<_i8.File>>()))
+          as _i4.Future<_i2.Result<List<_i8.File>>>);
+  @override
+  _i4.Future<_i2.Result<_i8.File?>> pickImage() => (super.noSuchMethod(
+          Invocation.method(#pickImage, []),
+          returnValue:
+              Future<_i2.Result<_i8.File?>>.value(_FakeResult_0<_i8.File?>()))
+      as _i4.Future<_i2.Result<_i8.File?>>);
 }


### PR DESCRIPTION
- #105 

### 実装済み
- 画像を選択・追加・変更・削除できるようにした
 → 基本はshopのコードのコピー

### 未実装
- フードタグ
- 登録者
- 動画
- テスト

### マイナーチェンジ
- [lib/ui/components/change_or_delete_dialog.dart](https://github.com/nasubibocchi/foodie_kyoto_post_app/pull/114/files#diff-8df9384fb52879b6d2d6f4e08ee1135ab4f0491a1bd9b17eeb0a68df4fa1ec34)
→ ダイアログをshopと共通化した。

Before | 画像選択後 | 画像タップ時
:--: | :--: | :--:
<img src="https://user-images.githubusercontent.com/87467867/172122282-17659595-c420-4cee-8f31-e09c64ff9494.PNG" width="240" /> | <img src="https://user-images.githubusercontent.com/87467867/172122456-ca26e769-45ea-4d36-9f5b-bf703c17d398.PNG" width="240" /> | <img src="https://user-images.githubusercontent.com/87467867/172122428-d659bb42-5df2-49b5-8597-d7c96130fa4b.PNG" width="240" />
