### PR TITLE
【menu編集】登録済みのmenuを編集する時はstateを初期化する処理を入れる

### DIFF
--- a/lib/ui/pages/post_menu_page/menu_image_widget.dart
+++ b/lib/ui/pages/post_menu_page/menu_image_widget.dart
@@ -2,20 +2,30 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/ui/components/change_or_delete_dialog.dart';
 import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+import 'package:tuple/tuple.dart';
 
 class MenuImageWidget extends ConsumerWidget {
-  const MenuImageWidget({Key? key, required this.shopId}) : super(key: key);
+  const MenuImageWidget({Key? key, required this.shopId, this.menu})
+      : super(key: key);
 
   final String shopId;
+  final Menu? menu;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final images = ref.watch(postMenuProvider(shopId).select((s) => s.images));
+    final images = ref.watch(postMenuProvider(Tuple2(shopId, menu)).select(
+      (s) => s.when((_, __, images, ___, ____, _____, ______, _______, ________,
+          _________, __________, ___________, ____________) {
+        return images;
+      }, error: () => []),
+    ));
+
     final controller = PageController(viewportFraction: 0.9);
 
     return images.isNotEmpty
@@ -39,7 +49,8 @@ class MenuImageWidget extends ConsumerWidget {
                                         onTapChange: () async {
                                       try {
                                         ref
-                                            .read(postMenuProvider(shopId)
+                                            .read(postMenuProvider(
+                                                    Tuple2(shopId, menu))
                                                 .notifier)
                                             .changeImage(index);
                                       } catch (e) {
@@ -55,8 +66,9 @@ class MenuImageWidget extends ConsumerWidget {
                                       }
                                     }, onTapDelete: () {
                                       ref
-                                          .read(
-                                              postMenuProvider(shopId).notifier)
+                                          .read(postMenuProvider(
+                                                  Tuple2(shopId, menu))
+                                              .notifier)
                                           .deleteSelectedImage(index);
                                     });
                                   });
@@ -85,7 +97,7 @@ class MenuImageWidget extends ConsumerWidget {
                   onPressed: () async {
                     try {
                       ref
-                          .read(postMenuProvider(shopId).notifier)
+                          .read(postMenuProvider(Tuple2(shopId, menu)).notifier)
                           .selectImages();
                     } catch (e) {
                       await showDialog(
@@ -112,7 +124,9 @@ class MenuImageWidget extends ConsumerWidget {
         : GestureDetector(
             onTap: () async {
               try {
-                ref.read(postMenuProvider(shopId).notifier).selectImages();
+                ref
+                    .read(postMenuProvider(Tuple2(shopId, menu)).notifier)
+                    .selectImages();
               } catch (e) {
                 await showDialog(
                     context: context,

--- a/lib/ui/pages/post_menu_page/post_menu_controller.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_controller.dart
@@ -14,8 +14,7 @@ part 'post_menu_controller.freezed.dart';
 @freezed
 class PostMenuState with _$PostMenuState {
   factory PostMenuState(
-      {required Menu? menu,
-      required String name,
+      {required String name,
       required TextEditingController nameController,
       @Default([]) List<File> images,
       File? movies,
@@ -28,165 +27,222 @@ class PostMenuState with _$PostMenuState {
       @Default([]) List<int> foodTags,
       @Default('') String postUser,
       @Default(false) bool isPosting}) = _PostMenuState;
+
+  factory PostMenuState.error() = _PostMenuStateError;
 }
 
 class PostMenuController extends StateNotifier<PostMenuState> {
   PostMenuController(this._menuUseCase, this._menuImageUseCase,
-      this._imageFileUseCase, this._shopId)
+      this._imageFileUseCase, this._shopId, this._menu)
       : super(PostMenuState(
-          menu: null,
           name: '',
           nameController: TextEditingController(text: ''),
           priceController: TextEditingController(text: ''),
           reviewController: TextEditingController(text: ''),
           enReviewController: TextEditingController(text: ''),
-        )) {
-    state.nameController.selection = TextSelection.fromPosition(
-        TextPosition(offset: state.nameController.text.length));
-    state.priceController.selection = TextSelection.fromPosition(
-        TextPosition(offset: state.priceController.text.length));
-    state.reviewController.selection = TextSelection.fromPosition(
-        TextPosition(offset: state.reviewController.text.length));
-    state.enReviewController.selection = TextSelection.fromPosition(
-        TextPosition(offset: state.enReviewController.text.length));
-  }
+        ));
 
   final MenuUseCase _menuUseCase;
   final MenuImageUseCase _menuImageUseCase;
   final ImageFileUseCase _imageFileUseCase;
   final String _shopId;
+  final Menu? _menu;
+
+  Future<void> initMenu() async {
+    if (_menu != null) {
+      state = PostMenuState(
+        name: _menu!.name,
+        nameController: TextEditingController.fromValue(TextEditingValue(
+            text: _menu!.name,
+            selection: TextSelection.collapsed(offset: _menu!.name.length))),
+        priceController: TextEditingController.fromValue(TextEditingValue(
+            text: '${_menu!.price}',
+            selection:
+                TextSelection.collapsed(offset: '${_menu!.price}'.length))),
+        reviewController: TextEditingController.fromValue(TextEditingValue(
+            text: _menu!.review,
+            selection: TextSelection.collapsed(offset: _menu!.review.length))),
+        enReviewController: TextEditingController.fromValue(TextEditingValue(
+            text: _menu!.enReview,
+            selection:
+                TextSelection.collapsed(offset: _menu!.enReview.length))),
+      );
+    } else {
+      final menu = Menu(
+          name: '',
+          shopId: _shopId,
+          images: [],
+          movies: [],
+          foodTags: [],
+          price: 0,
+          review: '',
+          enReview: '',
+          postUser: '');
+
+      state = PostMenuState(
+        name: menu.name,
+        nameController: TextEditingController.fromValue(TextEditingValue(
+            text: menu.name,
+            selection: TextSelection.collapsed(offset: menu.name.length))),
+        priceController: TextEditingController.fromValue(TextEditingValue(
+            text: '${menu.price}',
+            selection:
+                TextSelection.collapsed(offset: '${menu.price}'.length))),
+        reviewController: TextEditingController.fromValue(TextEditingValue(
+            text: menu.review,
+            selection: TextSelection.collapsed(offset: menu.review.length))),
+        enReviewController: TextEditingController.fromValue(TextEditingValue(
+            text: menu.enReview,
+            selection: TextSelection.collapsed(offset: menu.enReview.length))),
+      );
+    }
+  }
 
   void onEditMenuName(String name) {
-    final currentState = state;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
 
-    state = currentState.copyWith(name: name);
+      state = currentState.copyWith(name: name);
+    }
   }
 
   void onEditReview(String review) {
-    final currentState = state;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
 
-    state = currentState.copyWith(review: review);
+      state = currentState.copyWith(review: review);
+    }
   }
 
   void onEditEnglishReview(String enReview) {
-    final currentState = state;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
 
-    state = currentState.copyWith(enReview: enReview);
+      state = currentState.copyWith(enReview: enReview);
+    }
   }
 
   void onEditPrice(String number) {
-    final currentState = state;
-    final price = number == '' ? 0 : int.parse(number);
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
+      final price = number == '' ? 0 : int.parse(number);
 
-    state = currentState.copyWith(price: price);
+      state = currentState.copyWith(price: price);
+    }
   }
 
   Future<void> selectImages() async {
-    final currentState = state;
-    List<File> _imageList = currentState.images;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
+      List<File> _imageList = currentState.images;
 
-    final imagesResult = await _imageFileUseCase.pickMultiImage();
+      final imagesResult = await _imageFileUseCase.pickMultiImage();
 
-    imagesResult.whenWithResult(
-      (images) {
-        if (images.value.isNotEmpty) {
-          state = currentState.copyWith(images: _imageList + images.value);
-        }
-      },
-      (e) {
-        // errorが発生したらstateをエラー状態にしたいが、
-        // loading(メニュー編集機能で作成予定)stateとあわせて作りたいので
-        // いったん何もしない
-      },
-    );
+      imagesResult.whenWithResult(
+        (images) {
+          if (images.value.isNotEmpty) {
+            state = currentState.copyWith(images: _imageList + images.value);
+          }
+        },
+        (e) => state = PostMenuState.error(),
+      );
+    }
   }
 
   Future<void> changeImage(int index) async {
-    final currentState = state;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
 
-    final List<File> dupImages = List.of(currentState.images);
+      final List<File> dupImages = List.of(currentState.images);
 
-    final imageResult = await _imageFileUseCase.pickImage();
+      final imageResult = await _imageFileUseCase.pickImage();
 
-    imageResult.whenWithResult(
-      (image) {
-        if (image.value != null) {
-          dupImages[index] = image.value!;
-          state = currentState.copyWith(images: dupImages);
-        }
-      },
-      (e) {
-        // errorが発生したらstateをエラー状態にしたいが、
-        // loading(メニュー編集機能で作成予定)stateとあわせて作りたいので
-        // いったん何もしない
-      },
-    );
+      imageResult.whenWithResult(
+        (image) {
+          if (image.value != null) {
+            dupImages[index] = image.value!;
+            state = currentState.copyWith(images: dupImages);
+          }
+        },
+        (e) => state = PostMenuState.error(),
+      );
+    }
   }
 
   void deleteSelectedImage(int index) {
-    final currentState = state;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
 
-    final List<File> dupImages = List.of(currentState.images);
+      final List<File> dupImages = List.of(currentState.images);
 
-    dupImages.removeAt(index);
+      dupImages.removeAt(index);
 
-    state = currentState.copyWith(images: dupImages);
+      state = currentState.copyWith(images: dupImages);
+    }
   }
 
   Future<List<String>> getImageUrlFromStorage(List<String> imagePaths) async {
-    final currentState = state;
-    final menuName = currentState.name;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
+      final menuName = currentState.name;
 
-    for (int i = 0; i < imagePaths.length; i++) {
-      await _menuImageUseCase.postImages(
-          path: imagePaths[i],
-          shopId: _shopId,
-          menuName: menuName,
-          fileName: '$i');
+      for (int i = 0; i < imagePaths.length; i++) {
+        await _menuImageUseCase.postImages(
+            path: imagePaths[i],
+            shopId: _shopId,
+            menuName: menuName,
+            fileName: '$i');
+      }
+
+      final List<String> _imageUrlList = <String>[];
+      for (int i = 0; i < imagePaths.length; i++) {
+        final urlResult = await _menuImageUseCase.getImagesUrl(
+            path: imagePaths[i],
+            shopId: _shopId,
+            menuName: menuName,
+            fileName: '$i');
+
+        urlResult.whenWithResult((url) {
+          if (url.value != null) {
+            _imageUrlList.add(url.value!);
+          }
+        }, (failure) {});
+      }
+      return _imageUrlList;
+    } else {
+      return <String>[];
     }
-
-    final List<String> _imageUrlList = <String>[];
-    for (int i = 0; i < imagePaths.length; i++) {
-      final urlResult = await _menuImageUseCase.getImagesUrl(
-          path: imagePaths[i],
-          shopId: _shopId,
-          menuName: menuName,
-          fileName: '$i');
-
-      urlResult.whenWithResult((url) {
-        if (url.value != null) {
-          _imageUrlList.add(url.value!);
-        }
-      }, (failure) {});
-    }
-    return _imageUrlList;
   }
 
   Future<PostResults> createOrModifyMenu() async {
-    final currentState = state;
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
 
-    // 英語でのレビューは必須にはしない
-    if (currentState.review == '' ||
-        currentState.images == [] ||
-        currentState.movies == null) {
-      return PostResults.empty;
+      // 英語でのレビューは必須にはしない
+      if (currentState.review == '' ||
+          currentState.images == [] ||
+          currentState.movies == null) {
+        return PostResults.empty;
+      }
+
+      final menu = Menu(
+          name: currentState.name,
+          shopId: _shopId,
+          // images, moviesのコントローラは別途作る
+          images: [],
+          movies: [],
+          foodTags: currentState.foodTags,
+          price: currentState.price,
+          review: currentState.review,
+          enReview: currentState.enReview,
+          postUser: currentState.postUser);
+
+      final result = await _menuUseCase.createMenu(menu: menu);
+
+      return result.whenWithResult(
+          (success) => PostResults.success, (e) => PostResults.error);
+    } else {
+      return PostResults.abort;
     }
-
-    final menu = Menu(
-        name: currentState.name,
-        shopId: _shopId,
-        // images, moviesのコントローラは別途作る
-        images: [],
-        movies: [],
-        foodTags: currentState.foodTags,
-        price: currentState.price,
-        review: currentState.review,
-        enReview: currentState.enReview,
-        postUser: currentState.postUser);
-
-    final result = await _menuUseCase.createMenu(menu: menu);
-
-    return result.whenWithResult(
-        (success) => PostResults.success, (e) => PostResults.error);
   }
 }

--- a/lib/ui/pages/post_menu_page/post_menu_controller.freezed.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_controller.freezed.dart
@@ -16,27 +16,85 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$PostMenuState {
-  Menu? get menu => throw _privateConstructorUsedError;
-  String get name => throw _privateConstructorUsedError;
-  TextEditingController get nameController =>
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)
+        $default, {
+    required TResult Function() error,
+  }) =>
       throw _privateConstructorUsedError;
-  List<File> get images => throw _privateConstructorUsedError;
-  File? get movies => throw _privateConstructorUsedError;
-  int get price => throw _privateConstructorUsedError;
-  TextEditingController get priceController =>
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)?
+        $default, {
+    TResult Function()? error,
+  }) =>
       throw _privateConstructorUsedError;
-  String get review => throw _privateConstructorUsedError;
-  TextEditingController get reviewController =>
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)?
+        $default, {
+    TResult Function()? error,
+    required TResult orElse(),
+  }) =>
       throw _privateConstructorUsedError;
-  String get enReview => throw _privateConstructorUsedError;
-  TextEditingController get enReviewController =>
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_PostMenuState value) $default, {
+    required TResult Function(_PostMenuStateError value) error,
+  }) =>
       throw _privateConstructorUsedError;
-  List<int> get foodTags => throw _privateConstructorUsedError;
-  String get postUser => throw _privateConstructorUsedError;
-  bool get isPosting => throw _privateConstructorUsedError;
-
-  @JsonKey(ignore: true)
-  $PostMenuStateCopyWith<PostMenuState> get copyWith =>
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_PostMenuState value)? $default, {
+    TResult Function(_PostMenuStateError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_PostMenuState value)? $default, {
+    TResult Function(_PostMenuStateError value)? error,
+    required TResult orElse(),
+  }) =>
       throw _privateConstructorUsedError;
 }
 
@@ -45,21 +103,6 @@ abstract class $PostMenuStateCopyWith<$Res> {
   factory $PostMenuStateCopyWith(
           PostMenuState value, $Res Function(PostMenuState) then) =
       _$PostMenuStateCopyWithImpl<$Res>;
-  $Res call(
-      {Menu? menu,
-      String name,
-      TextEditingController nameController,
-      List<File> images,
-      File? movies,
-      int price,
-      TextEditingController priceController,
-      String review,
-      TextEditingController reviewController,
-      String enReview,
-      TextEditingController enReviewController,
-      List<int> foodTags,
-      String postUser,
-      bool isPosting});
 }
 
 /// @nodoc
@@ -70,95 +113,15 @@ class _$PostMenuStateCopyWithImpl<$Res>
   final PostMenuState _value;
   // ignore: unused_field
   final $Res Function(PostMenuState) _then;
-
-  @override
-  $Res call({
-    Object? menu = freezed,
-    Object? name = freezed,
-    Object? nameController = freezed,
-    Object? images = freezed,
-    Object? movies = freezed,
-    Object? price = freezed,
-    Object? priceController = freezed,
-    Object? review = freezed,
-    Object? reviewController = freezed,
-    Object? enReview = freezed,
-    Object? enReviewController = freezed,
-    Object? foodTags = freezed,
-    Object? postUser = freezed,
-    Object? isPosting = freezed,
-  }) {
-    return _then(_value.copyWith(
-      menu: menu == freezed
-          ? _value.menu
-          : menu // ignore: cast_nullable_to_non_nullable
-              as Menu?,
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      nameController: nameController == freezed
-          ? _value.nameController
-          : nameController // ignore: cast_nullable_to_non_nullable
-              as TextEditingController,
-      images: images == freezed
-          ? _value.images
-          : images // ignore: cast_nullable_to_non_nullable
-              as List<File>,
-      movies: movies == freezed
-          ? _value.movies
-          : movies // ignore: cast_nullable_to_non_nullable
-              as File?,
-      price: price == freezed
-          ? _value.price
-          : price // ignore: cast_nullable_to_non_nullable
-              as int,
-      priceController: priceController == freezed
-          ? _value.priceController
-          : priceController // ignore: cast_nullable_to_non_nullable
-              as TextEditingController,
-      review: review == freezed
-          ? _value.review
-          : review // ignore: cast_nullable_to_non_nullable
-              as String,
-      reviewController: reviewController == freezed
-          ? _value.reviewController
-          : reviewController // ignore: cast_nullable_to_non_nullable
-              as TextEditingController,
-      enReview: enReview == freezed
-          ? _value.enReview
-          : enReview // ignore: cast_nullable_to_non_nullable
-              as String,
-      enReviewController: enReviewController == freezed
-          ? _value.enReviewController
-          : enReviewController // ignore: cast_nullable_to_non_nullable
-              as TextEditingController,
-      foodTags: foodTags == freezed
-          ? _value.foodTags
-          : foodTags // ignore: cast_nullable_to_non_nullable
-              as List<int>,
-      postUser: postUser == freezed
-          ? _value.postUser
-          : postUser // ignore: cast_nullable_to_non_nullable
-              as String,
-      isPosting: isPosting == freezed
-          ? _value.isPosting
-          : isPosting // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
 }
 
 /// @nodoc
-abstract class _$$_PostMenuStateCopyWith<$Res>
-    implements $PostMenuStateCopyWith<$Res> {
+abstract class _$$_PostMenuStateCopyWith<$Res> {
   factory _$$_PostMenuStateCopyWith(
           _$_PostMenuState value, $Res Function(_$_PostMenuState) then) =
       __$$_PostMenuStateCopyWithImpl<$Res>;
-  @override
   $Res call(
-      {Menu? menu,
-      String name,
+      {String name,
       TextEditingController nameController,
       List<File> images,
       File? movies,
@@ -186,7 +149,6 @@ class __$$_PostMenuStateCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? menu = freezed,
     Object? name = freezed,
     Object? nameController = freezed,
     Object? images = freezed,
@@ -202,10 +164,6 @@ class __$$_PostMenuStateCopyWithImpl<$Res>
     Object? isPosting = freezed,
   }) {
     return _then(_$_PostMenuState(
-      menu: menu == freezed
-          ? _value.menu
-          : menu // ignore: cast_nullable_to_non_nullable
-              as Menu?,
       name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -266,8 +224,7 @@ class __$$_PostMenuStateCopyWithImpl<$Res>
 
 class _$_PostMenuState implements _PostMenuState {
   _$_PostMenuState(
-      {required this.menu,
-      required this.name,
+      {required this.name,
       required this.nameController,
       final List<File> images = const [],
       this.movies,
@@ -283,8 +240,6 @@ class _$_PostMenuState implements _PostMenuState {
       : _images = images,
         _foodTags = foodTags;
 
-  @override
-  final Menu? menu;
   @override
   final String name;
   @override
@@ -331,7 +286,7 @@ class _$_PostMenuState implements _PostMenuState {
 
   @override
   String toString() {
-    return 'PostMenuState(menu: $menu, name: $name, nameController: $nameController, images: $images, movies: $movies, price: $price, priceController: $priceController, review: $review, reviewController: $reviewController, enReview: $enReview, enReviewController: $enReviewController, foodTags: $foodTags, postUser: $postUser, isPosting: $isPosting)';
+    return 'PostMenuState(name: $name, nameController: $nameController, images: $images, movies: $movies, price: $price, priceController: $priceController, review: $review, reviewController: $reviewController, enReview: $enReview, enReviewController: $enReviewController, foodTags: $foodTags, postUser: $postUser, isPosting: $isPosting)';
   }
 
   @override
@@ -339,7 +294,6 @@ class _$_PostMenuState implements _PostMenuState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PostMenuState &&
-            const DeepCollectionEquality().equals(other.menu, menu) &&
             const DeepCollectionEquality().equals(other.name, name) &&
             const DeepCollectionEquality()
                 .equals(other.nameController, nameController) &&
@@ -362,7 +316,6 @@ class _$_PostMenuState implements _PostMenuState {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(menu),
       const DeepCollectionEquality().hash(name),
       const DeepCollectionEquality().hash(nameController),
       const DeepCollectionEquality().hash(_images),
@@ -381,12 +334,154 @@ class _$_PostMenuState implements _PostMenuState {
   @override
   _$$_PostMenuStateCopyWith<_$_PostMenuState> get copyWith =>
       __$$_PostMenuStateCopyWithImpl<_$_PostMenuState>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)
+        $default, {
+    required TResult Function() error,
+  }) {
+    return $default(
+        name,
+        nameController,
+        images,
+        movies,
+        price,
+        priceController,
+        review,
+        reviewController,
+        enReview,
+        enReviewController,
+        foodTags,
+        postUser,
+        isPosting);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)?
+        $default, {
+    TResult Function()? error,
+  }) {
+    return $default?.call(
+        name,
+        nameController,
+        images,
+        movies,
+        price,
+        priceController,
+        review,
+        reviewController,
+        enReview,
+        enReviewController,
+        foodTags,
+        postUser,
+        isPosting);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)?
+        $default, {
+    TResult Function()? error,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(
+          name,
+          nameController,
+          images,
+          movies,
+          price,
+          priceController,
+          review,
+          reviewController,
+          enReview,
+          enReviewController,
+          foodTags,
+          postUser,
+          isPosting);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_PostMenuState value) $default, {
+    required TResult Function(_PostMenuStateError value) error,
+  }) {
+    return $default(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_PostMenuState value)? $default, {
+    TResult Function(_PostMenuStateError value)? error,
+  }) {
+    return $default?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_PostMenuState value)? $default, {
+    TResult Function(_PostMenuStateError value)? error,
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(this);
+    }
+    return orElse();
+  }
 }
 
 abstract class _PostMenuState implements PostMenuState {
   factory _PostMenuState(
-      {required final Menu? menu,
-      required final String name,
+      {required final String name,
       required final TextEditingController nameController,
       final List<File> images,
       final File? movies,
@@ -400,40 +495,171 @@ abstract class _PostMenuState implements PostMenuState {
       final String postUser,
       final bool isPosting}) = _$_PostMenuState;
 
-  @override
-  Menu? get menu => throw _privateConstructorUsedError;
-  @override
   String get name => throw _privateConstructorUsedError;
-  @override
   TextEditingController get nameController =>
       throw _privateConstructorUsedError;
-  @override
   List<File> get images => throw _privateConstructorUsedError;
-  @override
   File? get movies => throw _privateConstructorUsedError;
-  @override
   int get price => throw _privateConstructorUsedError;
-  @override
   TextEditingController get priceController =>
       throw _privateConstructorUsedError;
-  @override
   String get review => throw _privateConstructorUsedError;
-  @override
   TextEditingController get reviewController =>
       throw _privateConstructorUsedError;
-  @override
   String get enReview => throw _privateConstructorUsedError;
-  @override
   TextEditingController get enReviewController =>
       throw _privateConstructorUsedError;
-  @override
   List<int> get foodTags => throw _privateConstructorUsedError;
-  @override
   String get postUser => throw _privateConstructorUsedError;
-  @override
   bool get isPosting => throw _privateConstructorUsedError;
-  @override
   @JsonKey(ignore: true)
   _$$_PostMenuStateCopyWith<_$_PostMenuState> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_PostMenuStateErrorCopyWith<$Res> {
+  factory _$$_PostMenuStateErrorCopyWith(_$_PostMenuStateError value,
+          $Res Function(_$_PostMenuStateError) then) =
+      __$$_PostMenuStateErrorCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$_PostMenuStateErrorCopyWithImpl<$Res>
+    extends _$PostMenuStateCopyWithImpl<$Res>
+    implements _$$_PostMenuStateErrorCopyWith<$Res> {
+  __$$_PostMenuStateErrorCopyWithImpl(
+      _$_PostMenuStateError _value, $Res Function(_$_PostMenuStateError) _then)
+      : super(_value, (v) => _then(v as _$_PostMenuStateError));
+
+  @override
+  _$_PostMenuStateError get _value => super._value as _$_PostMenuStateError;
+}
+
+/// @nodoc
+
+class _$_PostMenuStateError implements _PostMenuStateError {
+  _$_PostMenuStateError();
+
+  @override
+  String toString() {
+    return 'PostMenuState.error()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$_PostMenuStateError);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)
+        $default, {
+    required TResult Function() error,
+  }) {
+    return error();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)?
+        $default, {
+    TResult Function()? error,
+  }) {
+    return error?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String name,
+            TextEditingController nameController,
+            List<File> images,
+            File? movies,
+            int price,
+            TextEditingController priceController,
+            String review,
+            TextEditingController reviewController,
+            String enReview,
+            TextEditingController enReviewController,
+            List<int> foodTags,
+            String postUser,
+            bool isPosting)?
+        $default, {
+    TResult Function()? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_PostMenuState value) $default, {
+    required TResult Function(_PostMenuStateError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult Function(_PostMenuState value)? $default, {
+    TResult Function(_PostMenuStateError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_PostMenuState value)? $default, {
+    TResult Function(_PostMenuStateError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _PostMenuStateError implements PostMenuState {
+  factory _PostMenuStateError() = _$_PostMenuStateError;
 }

--- a/lib/ui/pages/post_menu_page/post_menu_page.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_page.dart
@@ -1,28 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_image_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tuple/tuple.dart';
 
 class PostMenuPage extends HookConsumerWidget {
-  const PostMenuPage({Key? key, required this.shopId}) : super(key: key);
+  const PostMenuPage({Key? key, required this.shopId, this.menu})
+      : super(key: key);
 
   final String shopId;
+  final Menu? menu;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final nameController =
-        ref.watch(postMenuProvider(shopId).select((s) => s.nameController));
-
-    final priceController =
-        ref.watch(postMenuProvider(shopId).select((s) => s.priceController));
-
-    final reviewController =
-        ref.watch(postMenuProvider(shopId).select((s) => s.reviewController));
-
-    final enReviewController =
-        ref.watch(postMenuProvider(shopId).select((s) => s.enReviewController));
+    final state = ref.watch(postMenuProvider(Tuple2(shopId, menu)));
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -35,163 +29,199 @@ class PostMenuPage extends HookConsumerWidget {
           style: TextStyle(color: AppColors.appBlack),
         ),
       ),
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            const Divider(
-              thickness: 4,
-              color: AppColors.appDarkBeige,
-              indent: 0,
-              endIndent: 0,
-            ),
-            MenuImageWidget(shopId: shopId),
-            const Divider(
-              thickness: 4,
-              color: AppColors.appDarkBeige,
-              indent: 0,
-              endIndent: 0,
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    'メニュー名',
-                    style: TextStyle(color: AppColors.appBlack, fontSize: 16),
-                  ),
-                  TextField(
-                    controller: nameController,
-                    decoration: const InputDecoration(
-                      hintText: '（必須）メニュー名を入力',
-                      hintStyle: TextStyle(color: Colors.grey),
-                      border: InputBorder.none,
-                    ),
-                    onChanged: ref
-                        .read(postMenuProvider(shopId).notifier)
-                        .onEditMenuName,
-                  ),
-                ],
-              ),
-            ),
-            const Divider(
-              thickness: 4,
-              color: AppColors.appDarkBeige,
-              indent: 0,
-              endIndent: 0,
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    'レビューコメント(日本語)',
-                    style: TextStyle(color: AppColors.appBlack, fontSize: 16),
-                  ),
-                  TextField(
-                    controller: reviewController,
-                    maxLines: 6,
-                    decoration: const InputDecoration(
-                      hintText: '（必須）日本語でレビューを入力',
-                      hintStyle: TextStyle(color: Colors.grey),
-                      border: InputBorder.none,
-                    ),
-                    onChanged: ref
-                        .read(postMenuProvider(shopId).notifier)
-                        .onEditReview,
-                  ),
-                ],
-              ),
-            ),
-            const Divider(
-              thickness: 4,
-              color: AppColors.appDarkBeige,
-              indent: 0,
-              endIndent: 0,
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    'レビューコメント(英語)',
-                    style: TextStyle(color: AppColors.appBlack, fontSize: 16),
-                  ),
-                  TextField(
-                    controller: enReviewController,
-                    maxLines: 6,
-                    decoration: const InputDecoration(
-                      hintText: '英語でレビューを入力',
-                      hintStyle: TextStyle(color: Colors.grey),
-                      border: InputBorder.none,
-                    ),
-                    onChanged: ref
-                        .read(postMenuProvider(shopId).notifier)
-                        .onEditEnglishReview,
-                  ),
-                ],
-              ),
-            ),
-            const Divider(
-              thickness: 4,
-              color: AppColors.appDarkBeige,
-              indent: 0,
-              endIndent: 0,
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    '料金',
-                    style: TextStyle(color: AppColors.appBlack, fontSize: 16),
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    crossAxisAlignment: CrossAxisAlignment.baseline,
-                    textBaseline: TextBaseline.alphabetic,
+      body: state.when(
+        (
+          _,
+          nameController,
+          __,
+          ___,
+          ____,
+          priceController,
+          _____,
+          reviewController,
+          ______,
+          enReviewController,
+          foodTags,
+          postUser,
+          isPosting,
+        ) {
+          return SingleChildScrollView(
+            child: Column(
+              children: [
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                MenuImageWidget(shopId: shopId),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Expanded(
-                        child: TextField(
-                          controller: priceController,
-                          textAlign: TextAlign.end,
-                          keyboardType: const TextInputType.numberWithOptions(
-                              signed: true, decimal: true),
-                          inputFormatters: [
-                            FilteringTextInputFormatter.digitsOnly
-                          ],
-                          decoration: const InputDecoration(
-                            hintText: '￥予算を入力',
-                            hintStyle: TextStyle(color: Colors.grey),
-                            border: InputBorder.none,
-                          ),
-                          onChanged: ref
-                              .read(postMenuProvider(shopId).notifier)
-                              .onEditPrice,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
                       const Text(
-                        '円',
+                        'メニュー名',
                         style:
-                            TextStyle(color: AppColors.appBlack, fontSize: 12),
+                            TextStyle(color: AppColors.appBlack, fontSize: 16),
+                      ),
+                      TextField(
+                        controller: nameController,
+                        decoration: const InputDecoration(
+                          hintText: '（必須）メニュー名を入力',
+                          hintStyle: TextStyle(color: Colors.grey),
+                          border: InputBorder.none,
+                        ),
+                        onChanged: ref
+                            .read(
+                                postMenuProvider(Tuple2(shopId, menu)).notifier)
+                            .onEditMenuName,
                       ),
                     ],
                   ),
-                ],
-              ),
+                ),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'レビューコメント(日本語)',
+                        style:
+                            TextStyle(color: AppColors.appBlack, fontSize: 16),
+                      ),
+                      TextField(
+                        controller: reviewController,
+                        maxLines: 6,
+                        decoration: const InputDecoration(
+                          hintText: '（必須）日本語でレビューを入力',
+                          hintStyle: TextStyle(color: Colors.grey),
+                          border: InputBorder.none,
+                        ),
+                        onChanged: ref
+                            .read(
+                                postMenuProvider(Tuple2(shopId, menu)).notifier)
+                            .onEditReview,
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'レビューコメント(英語)',
+                        style:
+                            TextStyle(color: AppColors.appBlack, fontSize: 16),
+                      ),
+                      TextField(
+                        controller: enReviewController,
+                        maxLines: 6,
+                        decoration: const InputDecoration(
+                          hintText: '英語でレビューを入力',
+                          hintStyle: TextStyle(color: Colors.grey),
+                          border: InputBorder.none,
+                        ),
+                        onChanged: ref
+                            .read(
+                                postMenuProvider(Tuple2(shopId, menu)).notifier)
+                            .onEditEnglishReview,
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '料金',
+                        style:
+                            TextStyle(color: AppColors.appBlack, fontSize: 16),
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        crossAxisAlignment: CrossAxisAlignment.baseline,
+                        textBaseline: TextBaseline.alphabetic,
+                        children: [
+                          Expanded(
+                            child: TextField(
+                              controller: priceController,
+                              textAlign: TextAlign.end,
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(
+                                      signed: true, decimal: true),
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly
+                              ],
+                              decoration: const InputDecoration(
+                                hintText: '￥予算を入力',
+                                hintStyle: TextStyle(color: Colors.grey),
+                                border: InputBorder.none,
+                              ),
+                              onChanged: ref
+                                  .read(postMenuProvider(Tuple2(shopId, menu))
+                                      .notifier)
+                                  .onEditPrice,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          const Text(
+                            '円',
+                            style: TextStyle(
+                                color: AppColors.appBlack, fontSize: 12),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+              ],
             ),
-            const Divider(
-              thickness: 4,
-              color: AppColors.appDarkBeige,
-              indent: 0,
-              endIndent: 0,
-            ),
-          ],
-        ),
+          );
+        },
+        error: () {
+          return const Center(
+            child: Text('error'),
+          );
+        },
       ),
     );
   }

--- a/lib/ui/pages/post_menu_page/post_menu_provider.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_provider.dart
@@ -2,6 +2,7 @@ import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:tuple/tuple.dart';
@@ -12,6 +13,7 @@ final postMenuProvider = StateNotifierProvider.family<
           ref.read(menuUseCaseProvider),
           ref.read(menuImageUseCaseProvider),
           ref.read(imageFileUseCaseProvider),
+          ref.read(pathUseCaseProvider),
           tuple.item1,
           tuple.item2,
         ));

--- a/lib/ui/pages/post_menu_page/post_menu_provider.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_provider.dart
@@ -1,13 +1,17 @@
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tuple/tuple.dart';
 
-final postMenuProvider =
-    StateNotifierProvider.family<PostMenuController, PostMenuState, String>(
-        (ref, shopId) => PostMenuController(
-            ref.read(menuUseCaseProvider),
-            ref.read(menuImageUseCaseProvider),
-            ref.read(imageFileUseCaseProvider),
-            shopId));
+final postMenuProvider = StateNotifierProvider.family<
+        PostMenuController, PostMenuState, Tuple2<String, Menu?>>(
+    (ref, tuple) => PostMenuController(
+          ref.read(menuUseCaseProvider),
+          ref.read(menuImageUseCaseProvider),
+          ref.read(imageFileUseCaseProvider),
+          tuple.item1,
+          tuple.item2,
+        ));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -917,6 +917,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  tuple:
+    dependency: "direct main"
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   path_provider: ^2.0.10
   smooth_page_indicator: ^1.0.0+2
   cached_network_image: ^3.2.1
+  tuple: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/post_menu_controller_test.dart
+++ b/test/post_menu_controller_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
@@ -7,6 +8,7 @@ import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/annotations.dart';
+import 'package:tuple/tuple.dart';
 
 import 'post_menu_controller_test.mocks.dart';
 
@@ -17,84 +19,189 @@ void main() {
   final _imageFileUseCase = MockImageFileUseCase();
 
   final container = ProviderContainer(overrides: [
-    postMenuProvider.overrideWithProvider(
-        StateNotifierProvider.family<PostMenuController, PostMenuState, String>(
-            (ref, _shopId) => PostMenuController(
-                _menuUseCase, _menuImageUseCase, _imageFileUseCase, _shopId))),
+    postMenuProvider.overrideWithProvider(StateNotifierProvider.family<
+            PostMenuController, PostMenuState, Tuple2<String, Menu?>>(
+        (ref, tuple) => PostMenuController(_menuUseCase, _menuImageUseCase,
+            _imageFileUseCase, tuple.item1, tuple.item2))),
   ]);
 
-  group('onEditMenuName', () {
+  group('when initial menu is defined', () {
     const shopId = 'shop_id_1';
-    final model = container.read(postMenuProvider(shopId).notifier);
+    final menu = Menu(
+        name: 'name',
+        shopId: shopId,
+        images: ['image1', 'image2'],
+        movies: ['movie1', 'movie2'],
+        foodTags: [1, 2, 3],
+        price: 500,
+        review: 'review',
+        enReview: 'enReview',
+        postUser: 'postUser');
 
-    test('when input string', () {
-      model.onEditMenuName('name');
-      expect(model.debugState.name, 'name');
-    });
+    final model =
+        container.read(postMenuProvider(Tuple2(shopId, menu)).notifier);
 
-    test('when input symbol', () {
-      model.onEditMenuName('🦆');
-      expect(model.debugState.name, '🦆');
+    group('initMenu', () {
+      test('checking initial menu', () async {
+        await model.initMenu();
+        model.debugState.when(
+          (name,
+              nameController,
+              images,
+              movies,
+              price,
+              priceController,
+              review,
+              reviewController,
+              enReview,
+              enReviewController,
+              foodTags,
+              postUser,
+              isPosting) {
+            expect(menu.name, 'name');
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
     });
   });
 
-  group('onEditReview', () {
+  group('when initial menu is not defined', () {
     const shopId = 'shop_id_1';
-    final model = container.read(postMenuProvider(shopId).notifier);
+    final model =
+        container.read(postMenuProvider(const Tuple2(shopId, null)).notifier);
+    group('onEditMenuName', () {
+      test('when input string', () {
+        model.onEditMenuName('name');
+        model.debugState.when(
+          (name, _, __, ___, ____, _____, ______, _______, ________, _________,
+              __________, ___________, ____________) {
+            expect(name, 'name');
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
 
-    test('when input string', () {
-      model.onEditReview('レビュー!');
-      expect(model.debugState.review, 'レビュー!');
+      test('when input symbol', () {
+        model.onEditMenuName('🦆');
+        model.debugState.when(
+          (name, _, __, ___, ____, _____, ______, _______, ________, _________,
+                  __________, ___________, ____________) =>
+              expect(name, '🦆'),
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
     });
 
-    test('when input symbol', () {
-      model.onEditReview('🦆');
-      expect(model.debugState.review, '🦆');
+    group('onEditReview', () {
+      test('when input string', () {
+        model.onEditReview('レビュー!');
+        model.debugState.when(
+          (_, __, ___, ____, _____, ______, review, _______, ________,
+              _________, __________, ___________, ____________) {
+            expect(review, 'レビュー!');
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
+
+      test('when input symbol', () {
+        model.onEditReview('🦆');
+        model.debugState.when(
+          (_, __, ___, ____, _____, ______, review, _______, ________,
+              _________, __________, ___________, ____________) {
+            expect(review, '🦆');
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
     });
-  });
 
-  group('onEditEnglishReview', () {
-    const shopId = 'shop_id_1';
-    final model = container.read(postMenuProvider(shopId).notifier);
+    group('onEditEnglishReview', () {
+      test('when input string', () {
+        model.onEditEnglishReview('review!');
+        model.debugState.when(
+          (_, __, ___, ____, _____, ______, _______, ________, enReview,
+              _________, __________, ___________, ____________) {
+            expect(enReview, 'review!');
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
 
-    test('when input string', () {
-      model.onEditReview('review!');
-      expect(model.debugState.review, 'review!');
+      test('when input symbol', () {
+        model.onEditEnglishReview('🦆');
+        model.debugState.when(
+          (_, __, ___, ____, _____, ______, _______, ________, enReview,
+              _________, __________, ___________, ____________) {
+            expect(enReview, '🦆');
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
     });
 
-    test('when input symbol', () {
-      model.onEditReview('🦆');
-      expect(model.debugState.review, '🦆');
+    group('onEditPrice', () {
+      test('when input number string', () {
+        model.onEditPrice('122334');
+        model.debugState.when(
+          (_, __, ___, ____, price, _____, ______, _______, ________, _________,
+              __________, ___________, ____________) {
+            expect(price, 122334);
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
+
+      test('when empty', () {
+        model.onEditPrice('');
+        model.debugState.when(
+          (_, __, ___, ____, price, _____, ______, _______, ________, _________,
+              __________, ___________, ____________) {
+            expect(price, 0);
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
     });
-  });
 
-  group('onEditPrice', () {
-    const shopId = 'shop_id_1';
-    final model = container.read(postMenuProvider(shopId).notifier);
+    group('postMenu', () {
+      test('when review comment is empty', () async {
+        model.onEditMenuName('name');
+        model.onEditPrice('300');
+        model.onEditReview('review');
 
-    test('when input number string', () {
-      model.onEditPrice('122334');
-      expect(model.debugState.price, 122334);
-    });
+        final result = await model.createOrModifyMenu();
 
-    test('when empty', () {
-      model.onEditPrice('');
-      expect(model.debugState.price, 0);
-    });
-  });
-
-  group('postMenu', () {
-    test('when review comment is empty', () async {
-      const shopId = 'shop_id_1';
-      final model = container.read(postMenuProvider(shopId).notifier);
-
-      model.onEditMenuName('name');
-      model.onEditPrice('300');
-      model.onEditReview('review');
-
-      final result = await model.createOrModifyMenu();
-
-      expect(result, PostResults.empty);
+        expect(result, PostResults.empty);
+      });
     });
   });
 }

--- a/test/post_menu_controller_test.dart
+++ b/test/post_menu_controller_test.dart
@@ -3,6 +3,7 @@ import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
@@ -12,62 +13,19 @@ import 'package:tuple/tuple.dart';
 
 import 'post_menu_controller_test.mocks.dart';
 
-@GenerateMocks([MenuUseCase, MenuImageUseCase, ImageFileUseCase])
+@GenerateMocks([MenuUseCase, MenuImageUseCase, ImageFileUseCase, PathUseCase])
 void main() {
   final _menuUseCase = MockMenuUseCase();
   final _menuImageUseCase = MockMenuImageUseCase();
   final _imageFileUseCase = MockImageFileUseCase();
+  final _pathUseCase = MockPathUseCase();
 
   final container = ProviderContainer(overrides: [
     postMenuProvider.overrideWithProvider(StateNotifierProvider.family<
             PostMenuController, PostMenuState, Tuple2<String, Menu?>>(
         (ref, tuple) => PostMenuController(_menuUseCase, _menuImageUseCase,
-            _imageFileUseCase, tuple.item1, tuple.item2))),
+            _imageFileUseCase, _pathUseCase, tuple.item1, tuple.item2))),
   ]);
-
-  group('when initial menu is defined', () {
-    const shopId = 'shop_id_1';
-    final menu = Menu(
-        name: 'name',
-        shopId: shopId,
-        images: ['image1', 'image2'],
-        movies: ['movie1', 'movie2'],
-        foodTags: [1, 2, 3],
-        price: 500,
-        review: 'review',
-        enReview: 'enReview',
-        postUser: 'postUser');
-
-    final model =
-        container.read(postMenuProvider(Tuple2(shopId, menu)).notifier);
-
-    group('initMenu', () {
-      test('checking initial menu', () async {
-        await model.initMenu();
-        model.debugState.when(
-          (name,
-              nameController,
-              images,
-              movies,
-              price,
-              priceController,
-              review,
-              reviewController,
-              enReview,
-              enReviewController,
-              foodTags,
-              postUser,
-              isPosting) {
-            expect(menu.name, 'name');
-          },
-          error: () {
-            // ignore: avoid_print
-            print('test is not passed');
-          },
-        );
-      });
-    });
-  });
 
   group('when initial menu is not defined', () {
     const shopId = 'shop_id_1';

--- a/test/post_menu_controller_test.mocks.dart
+++ b/test/post_menu_controller_test.mocks.dart
@@ -13,6 +13,8 @@ import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart'
     as _i6;
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart'
     as _i3;
+import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart'
+    as _i9;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -115,4 +117,20 @@ class MockImageFileUseCase extends _i1.Mock implements _i7.ImageFileUseCase {
           returnValue:
               Future<_i2.Result<_i8.File?>>.value(_FakeResult_0<_i8.File?>()))
       as _i4.Future<_i2.Result<_i8.File?>>);
+}
+
+/// A class which mocks [PathUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockPathUseCase extends _i1.Mock implements _i9.PathUseCase {
+  MockPathUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i4.Future<_i2.Result<_i8.Directory>> getTempDirectory() =>
+      (super.noSuchMethod(Invocation.method(#getTempDirectory, []),
+              returnValue: Future<_i2.Result<_i8.Directory>>.value(
+                  _FakeResult_0<_i8.Directory>()))
+          as _i4.Future<_i2.Result<_i8.Directory>>);
 }


### PR DESCRIPTION
- #115 

### 実装済み
- すでに登録してあるmenuを編集する時用に、post_menu_controllerのstateを初期化する
- 何らかの処理でエラーが出た時はstateをerrorにする

### 未実装
- 動画を登録
- 編集する時の関数は未実装（新しく作る時：createMenu()、編集するとき：modifyMenu() ）

先に動画、タグの実装やってからのほうがレビューしやすかったかもしれん💧🙏
