### PR TITLE
【menu登録機能】menuを編集できるようにする＆idを持たせる

### DIFF
--- a/lib/data/model/menu_model.dart
+++ b/lib/data/model/menu_model.dart
@@ -7,6 +7,7 @@ part 'menu_model.g.dart';
 @freezed
 class MenuModel with _$MenuModel {
   factory MenuModel({
+    required String menuId,
     required String name,
     required String shopId,
     required List<String> images,

--- a/lib/data/model/menu_model.freezed.dart
+++ b/lib/data/model/menu_model.freezed.dart
@@ -20,6 +20,7 @@ MenuModel _$MenuModelFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$MenuModel {
+  String get menuId => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   String get shopId => throw _privateConstructorUsedError;
   List<String> get images => throw _privateConstructorUsedError;
@@ -41,7 +42,8 @@ abstract class $MenuModelCopyWith<$Res> {
   factory $MenuModelCopyWith(MenuModel value, $Res Function(MenuModel) then) =
       _$MenuModelCopyWithImpl<$Res>;
   $Res call(
-      {String name,
+      {String menuId,
+      String name,
       String shopId,
       List<String> images,
       List<String> movies,
@@ -62,6 +64,7 @@ class _$MenuModelCopyWithImpl<$Res> implements $MenuModelCopyWith<$Res> {
 
   @override
   $Res call({
+    Object? menuId = freezed,
     Object? name = freezed,
     Object? shopId = freezed,
     Object? images = freezed,
@@ -73,6 +76,10 @@ class _$MenuModelCopyWithImpl<$Res> implements $MenuModelCopyWith<$Res> {
     Object? postUser = freezed,
   }) {
     return _then(_value.copyWith(
+      menuId: menuId == freezed
+          ? _value.menuId
+          : menuId // ignore: cast_nullable_to_non_nullable
+              as String,
       name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -120,7 +127,8 @@ abstract class _$$_MenuModelCopyWith<$Res> implements $MenuModelCopyWith<$Res> {
       __$$_MenuModelCopyWithImpl<$Res>;
   @override
   $Res call(
-      {String name,
+      {String menuId,
+      String name,
       String shopId,
       List<String> images,
       List<String> movies,
@@ -143,6 +151,7 @@ class __$$_MenuModelCopyWithImpl<$Res> extends _$MenuModelCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? menuId = freezed,
     Object? name = freezed,
     Object? shopId = freezed,
     Object? images = freezed,
@@ -154,6 +163,10 @@ class __$$_MenuModelCopyWithImpl<$Res> extends _$MenuModelCopyWithImpl<$Res>
     Object? postUser = freezed,
   }) {
     return _then(_$_MenuModel(
+      menuId: menuId == freezed
+          ? _value.menuId
+          : menuId // ignore: cast_nullable_to_non_nullable
+              as String,
       name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -198,7 +211,8 @@ class __$$_MenuModelCopyWithImpl<$Res> extends _$MenuModelCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_MenuModel extends _MenuModel {
   _$_MenuModel(
-      {required this.name,
+      {required this.menuId,
+      required this.name,
       required this.shopId,
       required final List<String> images,
       required final List<String> movies,
@@ -215,6 +229,8 @@ class _$_MenuModel extends _MenuModel {
   factory _$_MenuModel.fromJson(Map<String, dynamic> json) =>
       _$$_MenuModelFromJson(json);
 
+  @override
+  final String menuId;
   @override
   final String name;
   @override
@@ -251,7 +267,7 @@ class _$_MenuModel extends _MenuModel {
 
   @override
   String toString() {
-    return 'MenuModel(name: $name, shopId: $shopId, images: $images, movies: $movies, foodTags: $foodTags, price: $price, review: $review, enReview: $enReview, postUser: $postUser)';
+    return 'MenuModel(menuId: $menuId, name: $name, shopId: $shopId, images: $images, movies: $movies, foodTags: $foodTags, price: $price, review: $review, enReview: $enReview, postUser: $postUser)';
   }
 
   @override
@@ -259,6 +275,7 @@ class _$_MenuModel extends _MenuModel {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_MenuModel &&
+            const DeepCollectionEquality().equals(other.menuId, menuId) &&
             const DeepCollectionEquality().equals(other.name, name) &&
             const DeepCollectionEquality().equals(other.shopId, shopId) &&
             const DeepCollectionEquality().equals(other._images, _images) &&
@@ -274,6 +291,7 @@ class _$_MenuModel extends _MenuModel {
   @override
   int get hashCode => Object.hash(
       runtimeType,
+      const DeepCollectionEquality().hash(menuId),
       const DeepCollectionEquality().hash(name),
       const DeepCollectionEquality().hash(shopId),
       const DeepCollectionEquality().hash(_images),
@@ -297,7 +315,8 @@ class _$_MenuModel extends _MenuModel {
 
 abstract class _MenuModel extends MenuModel {
   factory _MenuModel(
-      {required final String name,
+      {required final String menuId,
+      required final String name,
       required final String shopId,
       required final List<String> images,
       required final List<String> movies,
@@ -311,6 +330,8 @@ abstract class _MenuModel extends MenuModel {
   factory _MenuModel.fromJson(Map<String, dynamic> json) =
       _$_MenuModel.fromJson;
 
+  @override
+  String get menuId => throw _privateConstructorUsedError;
   @override
   String get name => throw _privateConstructorUsedError;
   @override

--- a/lib/data/model/menu_model.g.dart
+++ b/lib/data/model/menu_model.g.dart
@@ -7,6 +7,7 @@ part of 'menu_model.dart';
 // **************************************************************************
 
 _$_MenuModel _$$_MenuModelFromJson(Map<String, dynamic> json) => _$_MenuModel(
+      menuId: json['menu_id'] as String,
       name: json['name'] as String,
       shopId: json['shop_id'] as String,
       images:
@@ -23,6 +24,7 @@ _$_MenuModel _$$_MenuModelFromJson(Map<String, dynamic> json) => _$_MenuModel(
 
 Map<String, dynamic> _$$_MenuModelToJson(_$_MenuModel instance) =>
     <String, dynamic>{
+      'menu_id': instance.menuId,
       'name': instance.name,
       'shop_id': instance.shopId,
       'images': instance.images,

--- a/lib/data/remote/data_source/menu_data_source.dart
+++ b/lib/data/remote/data_source/menu_data_source.dart
@@ -8,7 +8,7 @@ final menuDataSourceProvider = Provider<MenuDataSourceImpl>((ref) =>
     MenuDataSourceImpl(menuFirestore: ref.read(menuFirestoreProvider)));
 
 abstract class MenuDataSource {
-  Future<Result<MenuModel>> createMenu({required MenuModel menuModel});
+  Future<Result<MenuModel>> postMenu({required MenuModel menuModel});
 
   Future<Result<List<MenuModel>>> fetchShopMenus({required String shopId});
 }

--- a/lib/data/remote/data_source_impl/firestore_data_source_impl/menu_firestore.dart
+++ b/lib/data/remote/data_source_impl/firestore_data_source_impl/menu_firestore.dart
@@ -12,15 +12,31 @@ class MenuFirestore {
 
   final FirebaseFirestore _firestore;
 
-  Future<Result<Map<String, dynamic>>> createMenu(
+  Future<Result<Map<String, dynamic>>> postMenu(
       {required Map<String, dynamic> menuData}) async {
-    final ref = _firestore
-        .collection('shops')
-        .doc(menuData['shop_id'])
-        .collection('menus');
+    final DocumentReference ref;
+    final String menuId;
+    if (menuData['menu_id'] == '') {
+      ref = _firestore
+          .collection('shops')
+          .doc(menuData['shop_id'])
+          .collection('menus')
+          .doc();
+
+      menuId = ref.id;
+    } else {
+      ref = _firestore
+          .collection('shops')
+          .doc(menuData['shop_id'])
+          .collection('menus')
+          .doc(menuData['menu_id']);
+
+      menuId = menuData['menu_id'];
+    }
 
     try {
-      await ref.add(<String, dynamic>{
+      await ref.set(<String, dynamic>{
+        'menu_id': menuId,
         'name': menuData['name'],
         'shop_id': menuData['shop_id'],
         'images': menuData['images'],

--- a/lib/data/remote/data_source_impl/model_data_source_impl/menu_data_source_impl.dart
+++ b/lib/data/remote/data_source_impl/model_data_source_impl/menu_data_source_impl.dart
@@ -10,10 +10,10 @@ class MenuDataSourceImpl implements MenuDataSource {
   final MenuFirestore _menuFirestore;
 
   @override
-  Future<Result<MenuModel>> createMenu({required MenuModel menuModel}) async {
+  Future<Result<MenuModel>> postMenu({required MenuModel menuModel}) async {
     final menuData = menuModel.toJson();
 
-    final firestoreResult = await _menuFirestore.createMenu(menuData: menuData);
+    final firestoreResult = await _menuFirestore.postMenu(menuData: menuData);
 
     return firestoreResult.whenWithResult(
       (result) => Success(MenuModel.fromJson(result.value)),

--- a/lib/data/repository_impl/menu_repository_impl.dart
+++ b/lib/data/repository_impl/menu_repository_impl.dart
@@ -11,8 +11,9 @@ class MenuRepositoryImpl implements MenuRepository {
   final MenuDataSource _dataSource;
 
   @override
-  Future<Result<Menu>> createMenu({required Menu menu}) async {
+  Future<Result<Menu>> postMenu({required Menu menu}) async {
     final menuModel = MenuModel(
+        menuId: menu.menuId,
         name: menu.name,
         shopId: menu.shopId,
         images: menu.images,
@@ -23,11 +24,12 @@ class MenuRepositoryImpl implements MenuRepository {
         enReview: menu.enReview,
         postUser: menu.postUser);
 
-    final menuModelResult = await _dataSource.createMenu(menuModel: menuModel);
+    final menuModelResult = await _dataSource.postMenu(menuModel: menuModel);
 
     return menuModelResult.whenWithResult(
       (menuModel) => Success(
         Menu(
+            menuId: menuModel.value.menuId,
             name: menuModel.value.name,
             shopId: menuModel.value.shopId,
             images: menuModel.value.images,
@@ -51,6 +53,7 @@ class MenuRepositoryImpl implements MenuRepository {
         if (menuModelList.value.isNotEmpty) {
           final menuList = menuModelList.value
               .map((e) => Menu(
+                  menuId: e.menuId,
                   name: e.name,
                   shopId: e.shopId,
                   images: e.images,

--- a/lib/domain/entity/menu.dart
+++ b/lib/domain/entity/menu.dart
@@ -1,6 +1,7 @@
 class Menu {
   Menu(
-      {required this.name,
+      {required this.menuId,
+      required this.name,
       required this.shopId,
       required this.images,
       required this.movies,
@@ -10,6 +11,7 @@ class Menu {
       required this.enReview,
       required this.postUser});
 
+  final String menuId;
   final String name;
   final String shopId;
   final List<String> images;

--- a/lib/domain/repository/menu_repository.dart
+++ b/lib/domain/repository/menu_repository.dart
@@ -8,7 +8,7 @@ final menuRepositoryProvider = Provider<MenuRepositoryImpl>(
     (ref) => MenuRepositoryImpl(dataSource: ref.read(menuDataSourceProvider)));
 
 abstract class MenuRepository {
-  Future<Result<Menu>> createMenu({required Menu menu});
+  Future<Result<Menu>> postMenu({required Menu menu});
 
   Future<Result<List<Menu>>> fetchShopMenus({required String shopId});
 }

--- a/lib/domain/use_case/menu_use_case.dart
+++ b/lib/domain/use_case/menu_use_case.dart
@@ -11,8 +11,8 @@ class MenuUseCase {
 
   final MenuRepository _repository;
 
-  Future<Result<Menu>> createMenu({required Menu menu}) =>
-      _repository.createMenu(menu: menu);
+  Future<Result<Menu>> postMenu({required Menu menu}) =>
+      _repository.postMenu(menu: menu);
 
   Future<Result<List<Menu>>> fetchShopMenus({required String shopId}) =>
       _repository.fetchShopMenus(shopId: shopId);

--- a/lib/ui/pages/post_menu_page/post_menu_controller.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_controller.dart
@@ -89,6 +89,7 @@ class PostMenuController extends StateNotifier<PostMenuState> {
       );
     } else {
       final menu = Menu(
+          menuId: '',
           name: '',
           shopId: _shopId,
           images: [],
@@ -279,6 +280,7 @@ class PostMenuController extends StateNotifier<PostMenuState> {
 
         if (imagesUrl.isNotEmpty) {
           final menu = Menu(
+              menuId: _menu == null ? '' : _menu!.menuId,
               name: currentState.name,
               shopId: _shopId,
               // moviesのコントローラは別途作る
@@ -290,7 +292,7 @@ class PostMenuController extends StateNotifier<PostMenuState> {
               enReview: currentState.enReview,
               postUser: currentState.postUser);
 
-          final result = await _menuUseCase.createMenu(menu: menu);
+          final result = await _menuUseCase.postMenu(menu: menu);
           state = currentState.copyWith(isPosting: false);
 
           return result.whenWithResult(

--- a/test/menu_data_source_test.dart
+++ b/test/menu_data_source_test.dart
@@ -26,6 +26,7 @@ void main() {
 
   group('postShop', () {
     final menuData = {
+      'menu_id': 'menu_id_1',
       'name': 'menu_name_1',
       'shop_id': 'shop_id_1',
       'images': ['image1', 'image2'],
@@ -38,13 +39,15 @@ void main() {
     };
 
     test('it returns correct response when a menu posted', () async {
-      when(_menuFirestore.createMenu(menuData: menuData)).thenAnswer((_) async {
+      when(_menuFirestore.postMenu(menuData: menuData)).thenAnswer((_) async {
         final ref = _firestore
             .collection('shops')
             .doc(menuData['shop_id'] as String)
-            .collection('menus');
+            .collection('menus')
+            .doc(menuData['menu_id'] as String);
 
-        await ref.add(<String, dynamic>{
+        await ref.set(<String, dynamic>{
+          'menu_id': 'menu_id_1',
           'name': 'menu_name_1',
           'shop_id': 'shop_id_1',
           'images': ['image1', 'image2'],
@@ -61,12 +64,13 @@ void main() {
 
       final model = container.read(menuDataSourceProvider);
       final result =
-          await model.createMenu(menuModel: MenuModel.fromJson(menuData));
+          await model.postMenu(menuModel: MenuModel.fromJson(menuData));
 
       result.whenWithResult((success) {
         expect(
             success.value,
             MenuModel(
+                menuId: 'menu_id_1',
                 name: 'menu_name_1',
                 shopId: 'shop_id_1',
                 images: ['image1', 'image2'],
@@ -86,8 +90,9 @@ void main() {
   group('fetchShopMenus', () {
     const shopId = 'shop_id_2';
     final menuData = {
+      'menu_id': 'menu_id_1',
       'name': 'menu_name_1',
-      'shop_id': 'shop_id_1',
+      'shop_id': 'shop_id_2',
       'images': ['image1', 'image2'],
       'movies': ['movie1', 'movie2'],
       'food_tags': [1, 2, 3],

--- a/test/menu_data_source_test.mocks.dart
+++ b/test/menu_data_source_test.mocks.dart
@@ -31,7 +31,7 @@ class MockMenuFirestore extends _i1.Mock implements _i3.MenuFirestore {
   }
 
   @override
-  _i4.Future<_i2.Result<Map<String, dynamic>>> createMenu(
+  _i4.Future<_i2.Result<Map<String, dynamic>>> postMenu(
           {Map<String, dynamic>? menuData}) =>
       (super.noSuchMethod(
               Invocation.method(#createMenu, [], {#menuData: menuData}),

--- a/test/menu_data_source_test.mocks.dart
+++ b/test/menu_data_source_test.mocks.dart
@@ -34,7 +34,7 @@ class MockMenuFirestore extends _i1.Mock implements _i3.MenuFirestore {
   _i4.Future<_i2.Result<Map<String, dynamic>>> postMenu(
           {Map<String, dynamic>? menuData}) =>
       (super.noSuchMethod(
-              Invocation.method(#createMenu, [], {#menuData: menuData}),
+              Invocation.method(#postMenu, [], {#menuData: menuData}),
               returnValue: Future<_i2.Result<Map<String, dynamic>>>.value(
                   _FakeResult_0<Map<String, dynamic>>()))
           as _i4.Future<_i2.Result<Map<String, dynamic>>>);

--- a/test/menu_repository_test.dart
+++ b/test/menu_repository_test.dart
@@ -22,6 +22,7 @@ void main() {
 
   group('postMenu', () {
     final menu = Menu(
+        menuId: 'menu_id_1',
         name: 'menu_name_1',
         shopId: 'shop_id_1',
         images: ['image1', 'image2'],
@@ -33,6 +34,7 @@ void main() {
         postUser: 'user1');
 
     final menuModel = MenuModel(
+        menuId: menu.menuId,
         name: menu.name,
         shopId: menu.shopId,
         images: menu.images,
@@ -44,13 +46,13 @@ void main() {
         postUser: menu.postUser);
 
     test('it returns correct response when a menu posted', () async {
-      when(_menuDataSource.createMenu(menuModel: menuModel))
+      when(_menuDataSource.postMenu(menuModel: menuModel))
           .thenAnswer((_) async {
         return Success(menuModel);
       });
 
       final model = container.read(menuRepositoryProvider);
-      final result = await model.createMenu(menu: menu);
+      final result = await model.postMenu(menu: menu);
 
       result.whenWithResult((success) {
         expect(success.value.name, 'menu_name_1');
@@ -64,6 +66,7 @@ void main() {
   group('fetchShopMenus', () {
     const shopId = 'shop_id_1';
     final menuModel = MenuModel(
+        menuId: 'menu_id_1',
         name: 'menu_name_1',
         shopId: 'shop_id_1',
         images: ['image1', 'image2'],

--- a/test/menu_repository_test.mocks.dart
+++ b/test/menu_repository_test.mocks.dart
@@ -33,7 +33,7 @@ class MockMenuDataSource extends _i1.Mock implements _i3.MenuDataSource {
   @override
   _i4.Future<_i2.Result<_i5.MenuModel>> postMenu({_i5.MenuModel? menuModel}) =>
       (super.noSuchMethod(
-              Invocation.method(#createMenu, [], {#menuModel: menuModel}),
+              Invocation.method(#postMenu, [], {#menuModel: menuModel}),
               returnValue: Future<_i2.Result<_i5.MenuModel>>.value(
                   _FakeResult_0<_i5.MenuModel>()))
           as _i4.Future<_i2.Result<_i5.MenuModel>>);

--- a/test/menu_repository_test.mocks.dart
+++ b/test/menu_repository_test.mocks.dart
@@ -31,8 +31,7 @@ class MockMenuDataSource extends _i1.Mock implements _i3.MenuDataSource {
   }
 
   @override
-  _i4.Future<_i2.Result<_i5.MenuModel>> createMenu(
-          {_i5.MenuModel? menuModel}) =>
+  _i4.Future<_i2.Result<_i5.MenuModel>> postMenu({_i5.MenuModel? menuModel}) =>
       (super.noSuchMethod(
               Invocation.method(#createMenu, [], {#menuModel: menuModel}),
               returnValue: Future<_i2.Result<_i5.MenuModel>>.value(

--- a/test/model/menu_model_test.dart
+++ b/test/model/menu_model_test.dart
@@ -4,6 +4,7 @@ import 'package:foodie_kyoto_post_app/data/model/menu_model.dart';
 void main() {
   final data = [
     {
+      'menu_id': 'menu_id_1',
       'name': 'menu_name_1',
       'shop_id': 'shop_id_1',
       'images': ['image1', 'image2'],
@@ -20,6 +21,7 @@ void main() {
     final test = MenuModel.fromJson(data.first);
 
     final actual = MenuModel(
+        menuId: 'menu_id_1',
         name: 'menu_name_1',
         shopId: 'shop_id_1',
         images: ['image1', 'image2'],
@@ -37,6 +39,7 @@ void main() {
   group('copyWith', () {
     test('copyWith = original', () {
       final original = MenuModel(
+          menuId: 'menu_id_1',
           name: 'menu_name_1',
           shopId: 'shop_id_1',
           images: ['image1', 'image2'],
@@ -48,6 +51,7 @@ void main() {
           postUser: 'user1');
 
       final copyWith = original.copyWith(
+          menuId: original.menuId,
           name: original.name,
           shopId: original.shopId,
           images: original.images,
@@ -64,6 +68,7 @@ void main() {
 
     test('copyWith != original', () {
       final original = MenuModel(
+          menuId: 'menu_id_1',
           name: 'menu_name_1',
           shopId: 'shop_id_2',
           images: ['image1', 'image2'],
@@ -74,6 +79,7 @@ void main() {
           enReview: 'en_review1',
           postUser: 'user1');
       final copyWith = original.copyWith(
+          menuId: original.menuId,
           name: original.name,
           shopId: original.name,
           images: original.images,
@@ -90,6 +96,7 @@ void main() {
 
   test('toJson()', () {
     final ref = {
+      'menu_id': 'menu_id_1',
       'name': 'menu_name_1',
       'shop_id': 'shop_id_1',
       'images': ['image1', 'image2'],
@@ -102,6 +109,7 @@ void main() {
     };
 
     final original = MenuModel(
+        menuId: 'menu_id_1',
         name: 'menu_name_1',
         shopId: 'shop_id_1',
         images: ['image1', 'image2'],
@@ -118,6 +126,7 @@ void main() {
 
   test('toString()', () {
     const ref = 'MenuModel('
+        'menuId: menu_id_1, '
         'name: menu_name_1, '
         'shopId: shop_id_1, '
         'images: [image1, image2], '
@@ -129,6 +138,7 @@ void main() {
         'postUser: user1)';
 
     final original = MenuModel(
+        menuId: 'menu_id_1',
         name: 'menu_name_1',
         shopId: 'shop_id_1',
         images: ['image1', 'image2'],

--- a/test/post_menu_controller_test.mocks.dart
+++ b/test/post_menu_controller_test.mocks.dart
@@ -38,7 +38,7 @@ class MockMenuUseCase extends _i1.Mock implements _i3.MenuUseCase {
   }
 
   @override
-  _i4.Future<_i2.Result<_i5.Menu>> createMenu({_i5.Menu? menu}) =>
+  _i4.Future<_i2.Result<_i5.Menu>> postMenu({_i5.Menu? menu}) =>
       (super.noSuchMethod(Invocation.method(#createMenu, [], {#menu: menu}),
               returnValue:
                   Future<_i2.Result<_i5.Menu>>.value(_FakeResult_0<_i5.Menu>()))

--- a/test/post_menu_controller_test.mocks.dart
+++ b/test/post_menu_controller_test.mocks.dart
@@ -39,7 +39,7 @@ class MockMenuUseCase extends _i1.Mock implements _i3.MenuUseCase {
 
   @override
   _i4.Future<_i2.Result<_i5.Menu>> postMenu({_i5.Menu? menu}) =>
-      (super.noSuchMethod(Invocation.method(#createMenu, [], {#menu: menu}),
+      (super.noSuchMethod(Invocation.method(#postMenu, [], {#menu: menu}),
               returnValue:
                   Future<_i2.Result<_i5.Menu>>.value(_FakeResult_0<_i5.Menu>()))
           as _i4.Future<_i2.Result<_i5.Menu>>);


### PR DESCRIPTION
- #115 

- createMenu()をpostMenu()にリファクタ
　→ menuデータにIdを付けることで登録と編集を同じ関数で管理できるようにした
- menuデータにIdを加える

