### PR TITLE
【menu登録機能】動画を選択できるようにする

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.foodie_kyoto_post_app">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -76,6 +76,8 @@ PODS:
   - sqflite (0.0.2):
     - Flutter
     - FMDB (>= 2.7.5)
+  - video_player_avfoundation (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -89,6 +91,7 @@ DEPENDENCIES:
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/ios`)
 
 SPEC REPOS:
   trunk:
@@ -128,6 +131,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
+  video_player_avfoundation:
+    :path: ".symlinks/plugins/video_player_avfoundation/ios"
 
 CHECKOUT OPTIONS:
   FirebaseFirestore:
@@ -157,6 +162,7 @@ SPEC CHECKSUMS:
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
+  video_player_avfoundation: e489aac24ef5cf7af82702979ed16f2a5ef84cff
 
 PODFILE CHECKSUM: b83d54518ddb4d568ebaae31cf4f2b31bb2e695d
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,5 +49,12 @@
     <string>画像をアップロードするためにライブラリにアクセスします。</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+                  <dict>
+                    <key>NSAllowsArbitraryLoads</key>
+                    <true/>
+                  </dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
 </dict>
 </plist>

--- a/lib/data/local/data_source/movie_file_data_source.dart
+++ b/lib/data/local/data_source/movie_file_data_source.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:foodie_kyoto_post_app/data/local/data_source_impl/image_picker_data_source.dart';
+import 'package:foodie_kyoto_post_app/data/local/data_source_impl/movie_file_data_source_impl.dart';
+import 'package:foodie_kyoto_post_app/data/model/result.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final movieFileDataSourceProvider = Provider<MovieFileDataSourceImpl>((ref) =>
+    MovieFileDataSourceImpl(picker: ref.read(imagePickerDataSourceProvider)));
+
+abstract class MovieFileDataSource {
+  Future<Result<File?>> pickVideo();
+}

--- a/lib/data/local/data_source_impl/image_picker_data_source.dart
+++ b/lib/data/local/data_source_impl/image_picker_data_source.dart
@@ -28,4 +28,13 @@ class ImagePickerDataSource {
       return Error(e);
     }
   }
+
+  Future<Result<XFile?>> pickVideo() async {
+    try {
+      final pickerResult = await _picker.pickVideo(source: ImageSource.gallery);
+      return Success(pickerResult);
+    } on Exception catch (e) {
+      return Error(e);
+    }
+  }
 }

--- a/lib/data/local/data_source_impl/movie_file_data_source_impl.dart
+++ b/lib/data/local/data_source_impl/movie_file_data_source_impl.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:foodie_kyoto_post_app/data/local/data_source/movie_file_data_source.dart';
+import 'package:foodie_kyoto_post_app/data/local/data_source_impl/image_picker_data_source.dart';
+import 'package:foodie_kyoto_post_app/data/model/result.dart';
+
+class MovieFileDataSourceImpl implements MovieFileDataSource {
+  MovieFileDataSourceImpl({required ImagePickerDataSource picker})
+      : _picker = picker;
+
+  final ImagePickerDataSource _picker;
+
+  @override
+  Future<Result<File?>> pickVideo() async {
+    final fileResult = await _picker.pickVideo();
+
+    return fileResult.whenWithResult(
+      (xFile) {
+        if (xFile.value?.path != null) {
+          return Success(File(xFile.value!.path));
+        } else {
+          return Success(null);
+        }
+      },
+      (e) => Error(Exception(e)),
+    );
+  }
+}

--- a/lib/data/repository_impl/movie_file_repository_impl.dart
+++ b/lib/data/repository_impl/movie_file_repository_impl.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:foodie_kyoto_post_app/data/local/data_source/movie_file_data_source.dart';
+import 'package:foodie_kyoto_post_app/data/model/result.dart';
+import 'package:foodie_kyoto_post_app/domain/repository/movie_file_repository.dart';
+
+class MovieFileRepositoryImpl implements MovieFileRepository {
+  MovieFileRepositoryImpl({required MovieFileDataSource dataSource})
+      : _dataSource = dataSource;
+
+  final MovieFileDataSource _dataSource;
+
+  @override
+  Future<Result<File?>> pickVideo() async {
+    final dataSourceResult = await _dataSource.pickVideo();
+    return dataSourceResult.whenWithResult(
+      (file) => Success(file.value),
+      (e) => Error(Exception(e)),
+    );
+  }
+}

--- a/lib/domain/repository/movie_file_repository.dart
+++ b/lib/domain/repository/movie_file_repository.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:foodie_kyoto_post_app/data/local/data_source/movie_file_data_source.dart';
+import 'package:foodie_kyoto_post_app/data/model/result.dart';
+import 'package:foodie_kyoto_post_app/data/repository_impl/movie_file_repository_impl.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final movieFileRepositoryProvider = Provider<MovieFileRepositoryImpl>((ref) =>
+    MovieFileRepositoryImpl(dataSource: ref.read(movieFileDataSourceProvider)));
+
+abstract class MovieFileRepository {
+  Future<Result<File?>> pickVideo();
+}

--- a/lib/domain/use_case/menu_movie_use_case.dart
+++ b/lib/domain/use_case/menu_movie_use_case.dart
@@ -2,7 +2,7 @@ import 'package:foodie_kyoto_post_app/data/model/result.dart';
 import 'package:foodie_kyoto_post_app/domain/repository/menu_movie_repository.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-final menuMovieUseCase = Provider<MenuMovieUseCase>((ref) =>
+final menuMovieUseCaseProvider = Provider<MenuMovieUseCase>((ref) =>
     MenuMovieUseCase(repository: ref.read(menuMovieRepositoryProvider)));
 
 class MenuMovieUseCase {

--- a/lib/domain/use_case/movie_file_use_case.dart
+++ b/lib/domain/use_case/movie_file_use_case.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:foodie_kyoto_post_app/data/model/result.dart';
+import 'package:foodie_kyoto_post_app/domain/repository/movie_file_repository.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final movieFileUseCaseProvider = Provider<MovieFileUseCase>((ref) =>
+    MovieFileUseCase(repository: ref.read(movieFileRepositoryProvider)));
+
+class MovieFileUseCase {
+  MovieFileUseCase({required MovieFileRepository repository})
+      : _repository = repository;
+
+  final MovieFileRepository _repository;
+
+  Future<Result<File?>> pickVideo() => _repository.pickVideo();
+}

--- a/lib/ui/pages/post_menu_page/menu_movie_widget.dart
+++ b/lib/ui/pages/post_menu_page/menu_movie_widget.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
+import 'package:foodie_kyoto_post_app/ui/components/select_dialog.dart';
+import 'package:video_player/video_player.dart';
+
+class MenuMovieWidget extends StatefulWidget {
+  const MenuMovieWidget(
+      {Key? key,
+      required this.shopId,
+      required this.movies,
+      required this.onTapDeleteMovie,
+      required this.onTapAddMovie,
+      this.menu})
+      : super(key: key);
+
+  final String shopId;
+  final Menu? menu;
+  final File? movies;
+
+  final VoidCallback onTapDeleteMovie;
+  final VoidCallback onTapAddMovie;
+
+  @override
+  State<MenuMovieWidget> createState() => _MenuMovieWidgetState();
+}
+
+class _MenuMovieWidgetState extends State<MenuMovieWidget> {
+  VideoPlayerController? videoController;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void didUpdateWidget(MenuMovieWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.movies != null && oldWidget.movies != widget.movies) {
+      videoController = VideoPlayerController.file(widget.movies!)
+        ..initialize();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.movies != null
+        ? GestureDetector(
+            onTap: () async {
+              await showDialog(
+                  context: context,
+                  builder: (context) {
+                    return SelectDialog(
+                      '動画を削除',
+                      body: '選択した動画を削除します',
+                      onPressed: widget.onTapDeleteMovie,
+                    );
+                  });
+            },
+            child: SizedBox(
+              height: 352,
+              width: 176,
+              child: videoController != null
+                  ? Stack(children: [
+                      VideoPlayer(videoController!),
+                      videoController!.value.isPlaying
+                          ? Align(
+                              alignment: Alignment.topLeft,
+                              child: IconButton(
+                                  onPressed: () => setState(() {
+                                        videoController!.pause();
+                                      }),
+                                  icon: const Icon(Icons.stop_circle_rounded,
+                                      size: 36)),
+                            )
+                          : Align(
+                              alignment: Alignment.topLeft,
+                              child: IconButton(
+                                  onPressed: () => setState(() {
+                                        videoController!.play();
+                                      }),
+                                  icon: const Icon(
+                                      Icons.play_circle_fill_rounded,
+                                      size: 36)),
+                            ),
+                    ])
+                  : const SizedBox(),
+            ),
+          )
+        : GestureDetector(
+            onTap: widget.onTapAddMovie,
+            child: Container(
+              height: 100,
+              width: 350,
+              decoration: const BoxDecoration(color: AppColors.appBeige),
+              child: const Center(
+                child: Text(
+                  'タップして動画を追加',
+                  style: TextStyle(color: AppColors.appBlack),
+                ),
+              ),
+            ),
+          );
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    videoController?.dispose();
+  }
+}

--- a/lib/ui/pages/post_menu_page/post_menu_controller.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_controller.dart
@@ -6,6 +6,7 @@ import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_movie_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/movie_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -41,6 +42,7 @@ class PostMenuController extends StateNotifier<PostMenuState> {
       this._imageFileUseCase,
       this._pathUseCase,
       this._menuMovieUseCase,
+      this._movieFileUSeCase,
       this._shopId,
       this._menu)
       : super(PostMenuState(
@@ -56,6 +58,7 @@ class PostMenuController extends StateNotifier<PostMenuState> {
   final ImageFileUseCase _imageFileUseCase;
   final PathUseCase _pathUseCase;
   final MenuMovieUseCase _menuMovieUseCase;
+  final MovieFileUseCase _movieFileUSeCase;
   final String _shopId;
   final Menu? _menu;
 
@@ -235,6 +238,31 @@ class PostMenuController extends StateNotifier<PostMenuState> {
       dupImages.removeAt(index);
 
       state = currentState.copyWith(images: dupImages);
+    }
+  }
+
+  Future<void> selectMovie() async {
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
+
+      final movieResult = await _movieFileUSeCase.pickVideo();
+
+      movieResult.whenWithResult(
+        (movie) {
+          if (movie.value != null) {
+            state = currentState.copyWith(movies: movie.value);
+          }
+        },
+        (e) => state = PostMenuState.error(),
+      );
+    }
+  }
+
+  Future<void> deleteSelectedMovie() async {
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
+
+      state = currentState.copyWith(movies: null);
     }
   }
 

--- a/lib/ui/pages/post_menu_page/post_menu_controller.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_controller.dart
@@ -140,7 +140,7 @@ class PostMenuController extends StateNotifier<PostMenuState> {
     return tempDirResult.whenWithResult(
       (path) async {
         String tempPath = path.value.path;
-        final extension = isMovie ? '.MOV' : '.png';
+        final extension = isMovie ? '.mp4' : '.png';
 
         final File file = File('$tempPath/$fileName$extension');
 

--- a/lib/ui/pages/post_menu_page/post_menu_page.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
+import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_image_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_movie_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
@@ -35,7 +36,7 @@ class PostMenuPage extends HookConsumerWidget {
           _,
           nameController,
           __,
-          ___,
+          movies,
           ____,
           priceController,
           _____,
@@ -62,7 +63,29 @@ class PostMenuPage extends HookConsumerWidget {
                   indent: 0,
                   endIndent: 0,
                 ),
-                MenuMovieWidget(shopId: shopId),
+                MenuMovieWidget(
+                  shopId: shopId,
+                  movies: movies,
+                  onTapDeleteMovie: () => ref
+                      .read(postMenuProvider(Tuple2(shopId, menu)).notifier)
+                      .deleteSelectedMovie()
+                      .then((_) => Navigator.of(context).pop()),
+                  onTapAddMovie: () async {
+                    try {
+                      await ref
+                          .read(postMenuProvider(Tuple2(shopId, menu)).notifier)
+                          .selectMovie();
+                    } catch (e) {
+                      await showDialog(
+                          context: context,
+                          builder: (context) {
+                            return const OkDialog(
+                                title: 'エラー',
+                                body: '動画選択に失敗しました。もう一度試してみてください。');
+                          });
+                    }
+                  },
+                ),
                 const Divider(
                   thickness: 4,
                   color: AppColors.appDarkBeige,

--- a/lib/ui/pages/post_menu_page/post_menu_page.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_image_widget.dart';
+import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_movie_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:tuple/tuple.dart';
@@ -55,6 +56,13 @@ class PostMenuPage extends HookConsumerWidget {
                   endIndent: 0,
                 ),
                 MenuImageWidget(shopId: shopId),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                MenuMovieWidget(shopId: shopId),
                 const Divider(
                   thickness: 4,
                   color: AppColors.appDarkBeige,

--- a/lib/ui/pages/post_menu_page/post_menu_provider.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_provider.dart
@@ -3,6 +3,7 @@ import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_movie_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/movie_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -16,6 +17,7 @@ final postMenuProvider = StateNotifierProvider.family<
           ref.read(imageFileUseCaseProvider),
           ref.read(pathUseCaseProvider),
           ref.read(menuMovieUseCaseProvider),
+          ref.read(movieFileUseCaseProvider),
           tuple.item1,
           tuple.item2,
         ));

--- a/lib/ui/pages/post_menu_page/post_menu_provider.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_provider.dart
@@ -1,6 +1,7 @@
 import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_movie_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
@@ -14,6 +15,7 @@ final postMenuProvider = StateNotifierProvider.family<
           ref.read(menuImageUseCaseProvider),
           ref.read(imageFileUseCaseProvider),
           ref.read(pathUseCaseProvider),
+          ref.read(menuMovieUseCaseProvider),
           tuple.item1,
           tuple.item2,
         ));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,6 +197,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -443,6 +450,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   http:
     dependency: transitive
     description:
@@ -945,6 +959,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.4"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.6"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.5"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.3"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.10"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
 
   # Misc
   image_picker: ^0.8.5+3
+  video_player: ^2.4.2
   path_provider: ^2.0.10
   smooth_page_indicator: ^1.0.0+2
   cached_network_image: ^3.2.1

--- a/test/post_menu_controller_test.dart
+++ b/test/post_menu_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_movie_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/movie_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
@@ -21,7 +22,8 @@ import 'post_menu_controller_test.mocks.dart';
   MenuImageUseCase,
   ImageFileUseCase,
   PathUseCase,
-  MenuMovieUseCase
+  MenuMovieUseCase,
+  MovieFileUseCase,
 ])
 void main() {
   final _menuUseCase = MockMenuUseCase();
@@ -29,6 +31,7 @@ void main() {
   final _imageFileUseCase = MockImageFileUseCase();
   final _pathUseCase = MockPathUseCase();
   final _menuMovieUseCase = MockMenuMovieUseCase();
+  final _movieFileUseCase = MockMovieFileUseCase();
 
   final container = ProviderContainer(overrides: [
     postMenuProvider.overrideWithProvider(StateNotifierProvider.family<
@@ -39,6 +42,7 @@ void main() {
             _imageFileUseCase,
             _pathUseCase,
             _menuMovieUseCase,
+            _movieFileUseCase,
             tuple.item1,
             tuple.item2))),
   ]);

--- a/test/post_menu_controller_test.dart
+++ b/test/post_menu_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_movie_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_controller.dart';
@@ -13,18 +14,31 @@ import 'package:tuple/tuple.dart';
 
 import 'post_menu_controller_test.mocks.dart';
 
-@GenerateMocks([MenuUseCase, MenuImageUseCase, ImageFileUseCase, PathUseCase])
+@GenerateMocks([
+  MenuUseCase,
+  MenuImageUseCase,
+  ImageFileUseCase,
+  PathUseCase,
+  MenuMovieUseCase
+])
 void main() {
   final _menuUseCase = MockMenuUseCase();
   final _menuImageUseCase = MockMenuImageUseCase();
   final _imageFileUseCase = MockImageFileUseCase();
   final _pathUseCase = MockPathUseCase();
+  final _menuMovieUseCase = MockMenuMovieUseCase();
 
   final container = ProviderContainer(overrides: [
     postMenuProvider.overrideWithProvider(StateNotifierProvider.family<
             PostMenuController, PostMenuState, Tuple2<String, Menu?>>(
-        (ref, tuple) => PostMenuController(_menuUseCase, _menuImageUseCase,
-            _imageFileUseCase, _pathUseCase, tuple.item1, tuple.item2))),
+        (ref, tuple) => PostMenuController(
+            _menuUseCase,
+            _menuImageUseCase,
+            _imageFileUseCase,
+            _pathUseCase,
+            _menuMovieUseCase,
+            tuple.item1,
+            tuple.item2))),
   ]);
 
   group('when initial menu is not defined', () {

--- a/test/post_menu_controller_test.dart
+++ b/test/post_menu_controller_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:foodie_kyoto_post_app/data/model/result.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart';
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart';
@@ -10,6 +11,7 @@ import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider
 import 'package:foodie_kyoto_post_app/ui/pages/post_shop_page/post_shop_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tuple/tuple.dart';
 
 import 'post_menu_controller_test.mocks.dart';
@@ -166,9 +168,20 @@ void main() {
 
     group('postMenu', () {
       test('when review comment is empty', () async {
+        model.onEditReview('');
+
+        when(_menuImageUseCase.deleteImages(shopId: shopId, menuName: 'name'))
+            .thenAnswer((_) async {
+          return Success('path');
+        });
+
+        when(_menuMovieUseCase.deleteMovies(shopId: shopId, menuName: 'name'))
+            .thenAnswer((_) async {
+          return Success('path');
+        });
+
         model.onEditMenuName('name');
         model.onEditPrice('300');
-        model.onEditReview('review');
 
         final result = await model.createOrModifyMenu();
 

--- a/test/post_menu_controller_test.mocks.dart
+++ b/test/post_menu_controller_test.mocks.dart
@@ -15,6 +15,8 @@ import 'package:foodie_kyoto_post_app/domain/use_case/menu_movie_use_case.dart'
     as _i10;
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart'
     as _i3;
+import 'package:foodie_kyoto_post_app/domain/use_case/movie_file_use_case.dart'
+    as _i11;
 import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart'
     as _i9;
 import 'package:mockito/mockito.dart' as _i1;
@@ -180,4 +182,20 @@ class MockMenuMovieUseCase extends _i1.Mock implements _i10.MenuMovieUseCase {
               returnValue:
                   Future<_i2.Result<String>>.value(_FakeResult_0<String>()))
           as _i4.Future<_i2.Result<String>>);
+}
+
+/// A class which mocks [MovieFileUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockMovieFileUseCase extends _i1.Mock implements _i11.MovieFileUseCase {
+  MockMovieFileUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i4.Future<_i2.Result<_i8.File?>> pickVideo() => (super.noSuchMethod(
+          Invocation.method(#pickVideo, []),
+          returnValue:
+              Future<_i2.Result<_i8.File?>>.value(_FakeResult_0<_i8.File?>()))
+      as _i4.Future<_i2.Result<_i8.File?>>);
 }

--- a/test/post_menu_controller_test.mocks.dart
+++ b/test/post_menu_controller_test.mocks.dart
@@ -11,6 +11,8 @@ import 'package:foodie_kyoto_post_app/domain/use_case/image_file_use_case.dart'
     as _i7;
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_image_use_case.dart'
     as _i6;
+import 'package:foodie_kyoto_post_app/domain/use_case/menu_movie_use_case.dart'
+    as _i10;
 import 'package:foodie_kyoto_post_app/domain/use_case/menu_use_case.dart'
     as _i3;
 import 'package:foodie_kyoto_post_app/domain/use_case/path_use_case.dart'
@@ -133,4 +135,49 @@ class MockPathUseCase extends _i1.Mock implements _i9.PathUseCase {
               returnValue: Future<_i2.Result<_i8.Directory>>.value(
                   _FakeResult_0<_i8.Directory>()))
           as _i4.Future<_i2.Result<_i8.Directory>>);
+}
+
+/// A class which mocks [MenuMovieUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockMenuMovieUseCase extends _i1.Mock implements _i10.MenuMovieUseCase {
+  MockMenuMovieUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i4.Future<_i2.Result<String?>> postMovie(
+          {String? path, String? shopId, String? menuName, String? fileName}) =>
+      (super.noSuchMethod(
+              Invocation.method(#postMovie, [], {
+                #path: path,
+                #shopId: shopId,
+                #menuName: menuName,
+                #fileName: fileName
+              }),
+              returnValue:
+                  Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
+          as _i4.Future<_i2.Result<String?>>);
+  @override
+  _i4.Future<_i2.Result<String?>> getMovieUrl(
+          {String? path, String? shopId, String? menuName, String? fileName}) =>
+      (super.noSuchMethod(
+              Invocation.method(#getMovieUrl, [], {
+                #path: path,
+                #shopId: shopId,
+                #menuName: menuName,
+                #fileName: fileName
+              }),
+              returnValue:
+                  Future<_i2.Result<String?>>.value(_FakeResult_0<String?>()))
+          as _i4.Future<_i2.Result<String?>>);
+  @override
+  _i4.Future<_i2.Result<String>> deleteMovies(
+          {String? shopId, dynamic menuName}) =>
+      (super.noSuchMethod(
+              Invocation.method(
+                  #deleteMovies, [], {#shopId: shopId, #menuName: menuName}),
+              returnValue:
+                  Future<_i2.Result<String>>.value(_FakeResult_0<String>()))
+          as _i4.Future<_i2.Result<String>>);
 }


### PR DESCRIPTION
- #105 

### 変更点
- image pickerでライブラリから動画を選択できるようにする
- メニュー登録ページで選択した動画を確認できるようにする
- 選択した動画を削除できるようにする
- 選択した動画を削除した後、再選択できるようにする

### 未実装
- firestoreへの登録
- タグの選択と表示
- 登録した人の選択機能

<video src="https://user-images.githubusercontent.com/87467867/172518540-422e4d0a-4298-4fb6-8a2d-9405cc995b67.MOV" width="240" />
