### PR TITLE
【menu登録機能】フードタグを選択できるようにする

### DIFF
--- a/lib/ui/pages/post_menu_page/post_menu_controller.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_controller.dart
@@ -266,6 +266,25 @@ class PostMenuController extends StateNotifier<PostMenuState> {
     }
   }
 
+  void addFoodTag(int key) {
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
+
+      state = currentState.copyWith(foodTags: currentState.foodTags + [key]);
+    }
+  }
+
+  void removeFoodTag(int key) {
+    if (state is _PostMenuState) {
+      final currentState = state as _PostMenuState;
+
+      final foodTags = List.of(currentState.foodTags);
+      foodTags.remove(key);
+
+      state = currentState.copyWith(foodTags: foodTags);
+    }
+  }
+
   Future<List<String>> getImageUrlFromStorage(List<String> imagePaths) async {
     if (state is _PostMenuState) {
       final currentState = state as _PostMenuState;

--- a/lib/ui/pages/post_menu_page/post_menu_page.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:foodie_kyoto_post_app/constants/app_colors.dart';
+import 'package:foodie_kyoto_post_app/constants/tags_data.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/ui/components/ok_dialog.dart';
+import 'package:foodie_kyoto_post_app/ui/components/tag_button.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_image_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/menu_movie_widget.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_provider.dart';
@@ -244,6 +246,21 @@ class PostMenuPage extends HookConsumerWidget {
                   indent: 0,
                   endIndent: 0,
                 ),
+                _FoodTagsWidget(shopId: shopId, menu: menu),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                _SelectedTagsWidget(shopId: shopId, menu: menu),
+                const Divider(
+                  thickness: 4,
+                  color: AppColors.appDarkBeige,
+                  indent: 0,
+                  endIndent: 0,
+                ),
+                const SizedBox(height: 24),
               ],
             ),
           );
@@ -253,6 +270,134 @@ class PostMenuPage extends HookConsumerWidget {
             child: Text('error'),
           );
         },
+      ),
+    );
+  }
+}
+
+class _FoodTagsWidget extends ConsumerWidget {
+  const _FoodTagsWidget({required this.shopId, required this.menu});
+
+  final String shopId;
+  final Menu? menu;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedFoodTags =
+        ref.watch(postMenuProvider(Tuple2(shopId, menu)).select((s) => s.when(
+              (_, __, ___, ____, _____, ______, _______, ________, _________,
+                      __________, foodTags, ___________, ____________) =>
+                  foodTags,
+              error: () => [],
+            )));
+
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+      ),
+      child: Column(
+        children: [
+          const Align(
+            alignment: Alignment.topLeft,
+            child: Padding(
+              padding: EdgeInsets.all(8),
+              child: Text(
+                'フード',
+                style: TextStyle(color: AppColors.appBlack, fontSize: 16),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Wrap(
+                spacing: 16,
+                children: FoodTags.foodTags.entries
+                    .map((e) => TagButton(
+                        onTap: () {
+                          ref
+                              .read(postMenuProvider(Tuple2(shopId, menu))
+                                  .notifier)
+                              .addFoodTag(e.key);
+                        },
+                        onTapCloseIcon: () {
+                          ref
+                              .read(postMenuProvider(Tuple2(shopId, menu))
+                                  .notifier)
+                              .removeFoodTag(e.key);
+                        },
+                        tagName: e.value,
+                        isSelected: selectedFoodTags.contains(e.key)))
+                    .toList(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SelectedTagsWidget extends ConsumerWidget {
+  const _SelectedTagsWidget(
+      {Key? key, required this.shopId, required this.menu})
+      : super(key: key);
+
+  final String shopId;
+  final Menu? menu;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedFoodTags =
+        ref.watch(postMenuProvider(Tuple2(shopId, menu)).select((s) => s.when(
+              (_, __, ___, ____, _____, ______, _______, ________, _________,
+                      __________, foodTags, ___________, ____________) =>
+                  foodTags,
+              error: () => [],
+            )));
+
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: SizedBox(
+        child: Column(mainAxisAlignment: MainAxisAlignment.start, children: [
+          const Align(
+            alignment: Alignment.topLeft,
+            child: Text(
+              '選択済みタグ',
+              style: TextStyle(color: AppColors.appBlack, fontSize: 16),
+            ),
+          ),
+          Align(
+            alignment: Alignment.topLeft,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: FoodTags.foodTags.entries
+                    .map((e) => selectedFoodTags.contains(e.key)
+                        ? TagButton(
+                            onTap: () {
+                              ref
+                                  .read(postMenuProvider(Tuple2(shopId, menu))
+                                      .notifier)
+                                  .addFoodTag(e.key);
+                            },
+                            onTapCloseIcon: () {
+                              ref
+                                  .read(postMenuProvider(Tuple2(shopId, menu))
+                                      .notifier)
+                                  .removeFoodTag(e.key);
+                            },
+                            tagName: e.value,
+                            isSelected: selectedFoodTags.contains(e.key))
+                        : const SizedBox())
+                    .toList(),
+              ),
+            ),
+          ),
+        ]),
       ),
     );
   }

--- a/test/post_menu_controller_test.dart
+++ b/test/post_menu_controller_test.dart
@@ -170,6 +170,39 @@ void main() {
       });
     });
 
+    group('addFoodTag', () {
+      test('when add the food tag of key 1', () {
+        model.addFoodTag(1);
+        model.debugState.when(
+          (_, __, ___, ____, ____________, _____, ______, _______, ________,
+              _________, foodTags, __________, ___________) {
+            expect(foodTags.length, 1);
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
+    });
+
+    group('removeFoodTag', () {
+      test('when add the food tag of key 1', () {
+        // 'addFoodTag' でタグが一つ選択されている状態から始まる
+        model.removeFoodTag(1);
+        model.debugState.when(
+          (_, __, ___, ____, ____________, _____, ______, _______, ________,
+              _________, foodTags, __________, ___________) {
+            expect(foodTags.length, 0);
+          },
+          error: () {
+            // ignore: avoid_print
+            print('test is not passed');
+          },
+        );
+      });
+    });
+
     group('postMenu', () {
       test('when review comment is empty', () async {
         model.onEditReview('');


### PR DESCRIPTION
- #122 

### 変更点
- メニュー登録（編集）ページにタグ選択エリア、選択済みタグエリアを表示
- タグボタンをタップしたらcontrollerでタグ選択状態を変更する関数を追加

### 未実装
- firestoreへの登録
- 誰が登録したかを選択する機能

<img src="https://user-images.githubusercontent.com/87467867/172527136-a5f1dc2b-1c06-46da-9f09-a79b582f4204.PNG" width="240" />