### PR TITLE
【お店の詳細ページ】レイアウト修正

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:foodie_kyoto_post_app/constants.dart';
+import 'package:foodie_kyoto_post_app/domain/entity/menu.dart';
 import 'package:foodie_kyoto_post_app/domain/entity/shop.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/google_map_page/google_map_page.dart';
 import 'package:foodie_kyoto_post_app/ui/pages/post_menu_page/post_menu_page.dart';
@@ -38,13 +39,26 @@ final routerProvider = Provider<GoRouter>((ref) => GoRouter(routes: <GoRoute>[
             ),
             GoRoute(
               path: RouteNames.shopDetailPage,
-              pageBuilder: (context, state) => MaterialPage(
-                  child: ShopDetailPage(shop: state.extra as Shop)),
+              pageBuilder: (context, state) {
+                final Map<String, Object?> params =
+                    state.extra! as Map<String, Object?>;
+                final Shop shop = params['shop'] as Shop;
+
+                return MaterialPage(child: ShopDetailPage(shop: shop));
+              },
               routes: [
                 GoRoute(
                   path: RouteNames.postMenuPage,
-                  pageBuilder: (context, state) => MaterialPage(
-                      child: PostMenuPage(shopId: state.extra as String)),
+                  pageBuilder: (context, state) {
+                    final Map<String, Object?> params =
+                        state.extra! as Map<String, Object?>;
+
+                    final Shop shop = params['shop'] as Shop;
+                    final Menu? menu = params['menu'] as Menu?;
+
+                    return MaterialPage(
+                        child: PostMenuPage(shopId: shop.shopId, menu: menu));
+                  },
                 ),
               ],
             ),

--- a/lib/ui/pages/google_map_page/shop_information_widget.dart
+++ b/lib/ui/pages/google_map_page/shop_information_widget.dart
@@ -19,7 +19,7 @@ class ShopInformationWidget extends StatelessWidget {
       width: 400,
       child: GestureDetector(
         onTap: () {
-          context.go('/${RouteNames.shopDetailPage}', extra: shop);
+          context.go('/${RouteNames.shopDetailPage}', extra: {'shop': shop});
         },
         child: Card(
           shape: RoundedRectangleBorder(

--- a/lib/ui/pages/post_menu_page/post_menu_controller.dart
+++ b/lib/ui/pages/post_menu_page/post_menu_controller.dart
@@ -52,7 +52,9 @@ class PostMenuController extends StateNotifier<PostMenuState> {
           priceController: TextEditingController(text: ''),
           reviewController: TextEditingController(text: ''),
           enReviewController: TextEditingController(text: ''),
-        ));
+        )) {
+    initMenu();
+  }
 
   final MenuUseCase _menuUseCase;
   final MenuImageUseCase _menuImageUseCase;

--- a/lib/ui/pages/shop_detail_page/shop_detail_page.dart
+++ b/lib/ui/pages/shop_detail_page/shop_detail_page.dart
@@ -327,12 +327,6 @@ class _MenuWidget extends StatelessWidget {
                     alignment: Alignment.topRight,
                     child: GestureDetector(
                       onTap: onTapEditIcon,
-                      // onTap: () {
-                      //   context.go(
-                      //     '/${RouteNames.shopDetailPage}/${RouteNames.postMenuPage}',
-                      //     extra: menu,
-                      //   );
-                      // },
                       child: Container(
                         margin: const EdgeInsets.all(4),
                         padding: const EdgeInsets.all(2),

--- a/lib/ui/pages/shop_detail_page/shop_detail_page.dart
+++ b/lib/ui/pages/shop_detail_page/shop_detail_page.dart
@@ -11,9 +11,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 class ShopDetailPage extends HookConsumerWidget {
-  const ShopDetailPage({Key? key, required this.shop}) : super(key: key);
+  ShopDetailPage({Key? key, required this.shop}) : super(key: key);
 
   final Shop shop;
+  final GlobalKey scaffoldKey = GlobalKey();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -29,6 +30,7 @@ class ShopDetailPage extends HookConsumerWidget {
         shop.foodTags.map((key) => FoodTags.foodTags[key]).toList();
 
     return Scaffold(
+      key: scaffoldKey,
       backgroundColor: Colors.white,
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -139,7 +141,7 @@ class ShopDetailPage extends HookConsumerWidget {
                             Text(
                               '¥${shop.price}',
                               style: const TextStyle(
-                                  color: AppColors.appBlack, fontSize: 14),
+                                  color: AppColors.appBlack, fontSize: 16),
                             ),
                             const SizedBox(width: 2),
                             const Text(
@@ -159,7 +161,7 @@ class ShopDetailPage extends HookConsumerWidget {
                     endIndent: 0,
                   ),
                   Padding(
-                    padding: const EdgeInsets.all(8),
+                    padding: const EdgeInsets.all(16),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -183,7 +185,7 @@ class ShopDetailPage extends HookConsumerWidget {
                     endIndent: 0,
                   ),
                   Padding(
-                    padding: const EdgeInsets.all(8),
+                    padding: const EdgeInsets.all(16),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -198,9 +200,12 @@ class ShopDetailPage extends HookConsumerWidget {
                               alignment: Alignment.topRight,
                               child: GestureDetector(
                                 onTap: () {
-                                  context.go(
+                                  scaffoldKey.currentContext!.go(
                                     '/${RouteNames.shopDetailPage}/${RouteNames.postMenuPage}',
-                                    extra: shop.shopId,
+                                    extra: <String, Object?>{
+                                      'shop': shop,
+                                      'menu': null
+                                    },
                                   );
                                 },
                                 child: const Icon(
@@ -215,13 +220,24 @@ class ShopDetailPage extends HookConsumerWidget {
                         const SizedBox(height: 8),
                         menu.isNotEmpty
                             ? SizedBox(
-                                height: 100,
+                                height: 100.0 * menu.length,
                                 child: ListView.builder(
                                     physics:
                                         const NeverScrollableScrollPhysics(),
                                     itemCount: menu.length,
                                     itemBuilder: (context, int index) {
-                                      return _MenuWidget(menu: menu[index]);
+                                      return _MenuWidget(
+                                        menu: menu[index],
+                                        onTapEditIcon: () {
+                                          scaffoldKey.currentContext!.go(
+                                            '/${RouteNames.shopDetailPage}/${RouteNames.postMenuPage}',
+                                            extra: <String, Object>{
+                                              'shop': shop,
+                                              'menu': menu[index]
+                                            },
+                                          );
+                                        },
+                                      );
                                     }),
                               )
                             : const Text(
@@ -280,14 +296,16 @@ class _TagWidget extends StatelessWidget {
 }
 
 class _MenuWidget extends StatelessWidget {
-  const _MenuWidget({Key? key, required this.menu}) : super(key: key);
+  const _MenuWidget({Key? key, required this.menu, required this.onTapEditIcon})
+      : super(key: key);
 
   final Menu menu;
+  final VoidCallback onTapEditIcon;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 2),
       child: Container(
           height: 96,
           width: double.infinity,
@@ -298,68 +316,83 @@ class _MenuWidget extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              SizedBox(
-                height: 96,
-                width: 96,
-                child: CachedNetworkImage(imageUrl: menu.images.first),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Stack(
-                  children: [
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.start,
-                          crossAxisAlignment: CrossAxisAlignment.baseline,
-                          textBaseline: TextBaseline.alphabetic,
-                          children: [
-                            Text(
-                              menu.name,
-                              style: const TextStyle(
-                                  color: AppColors.appBlack,
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.bold),
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              '¥${menu.price}',
-                              style: const TextStyle(
-                                  color: AppColors.appBlack, fontSize: 12),
-                            ),
-                          ],
+              Stack(
+                children: [
+                  SizedBox(
+                    height: 96,
+                    width: 96,
+                    child: CachedNetworkImage(imageUrl: menu.images.first),
+                  ),
+                  Align(
+                    alignment: Alignment.topRight,
+                    child: GestureDetector(
+                      onTap: onTapEditIcon,
+                      // onTap: () {
+                      //   context.go(
+                      //     '/${RouteNames.shopDetailPage}/${RouteNames.postMenuPage}',
+                      //     extra: menu,
+                      //   );
+                      // },
+                      child: Container(
+                        margin: const EdgeInsets.all(4),
+                        padding: const EdgeInsets.all(2),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(4),
                         ),
-                        Text(
-                          menu.postUser,
-                          style: const TextStyle(
-                              color: AppColors.appBlack, fontSize: 12),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                              vertical: 8, horizontal: 0),
-                          child: Text(
-                            menu.review,
-                            maxLines: 3,
-                            style: const TextStyle(
-                                color: AppColors.appBlack, fontSize: 12),
-                          ),
-                        )
-                      ],
-                    ),
-                    Align(
-                      alignment: Alignment.topRight,
-                      child: GestureDetector(
-                        onTap: () {
-                          // メニュー編集ページへ移動
-                        },
                         child: const Icon(
                           Icons.edit_rounded,
-                          color: AppColors.appGrey,
+                          color: AppColors.appOrange,
                           size: 24,
                         ),
                       ),
                     ),
+                  ),
+                ],
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 4),
+                    Text(
+                      menu.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                          color: AppColors.appBlack,
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(width: 16),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        Text(
+                          '¥${menu.price}',
+                          style: const TextStyle(
+                              color: AppColors.appBlack, fontSize: 12),
+                        ),
+                        const SizedBox(width: 16),
+                        Text(
+                          '投稿者：${menu.postUser}',
+                          style: const TextStyle(
+                              color: AppColors.appBlack, fontSize: 12),
+                        ),
+                      ],
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 8, horizontal: 0),
+                      child: Text(
+                        menu.review,
+                        maxLines: 2,
+                        overflow: TextOverflow.fade,
+                        style: const TextStyle(
+                            color: AppColors.appBlack, fontSize: 12),
+                      ),
+                    )
                   ],
                 ),
               ),

--- a/lib/ui/pages/shop_detail_page/shop_detail_page.dart
+++ b/lib/ui/pages/shop_detail_page/shop_detail_page.dart
@@ -336,7 +336,7 @@ class _MenuWidget extends StatelessWidget {
                         ),
                         child: const Icon(
                           Icons.edit_rounded,
-                          color: AppColors.appOrange,
+                          color: AppColors.appGrey,
                           size: 24,
                         ),
                       ),


### PR DESCRIPTION
- #123 

メニューを登録できるようになったので、レイアウト確認。
→ レイアウト崩れ含めて見た目を修正。

また、メニュー追加（+ボタン）と編集（鉛筆アイコン）をタップした時に遷移できるようにした。

<img src="https://user-images.githubusercontent.com/87467867/172575653-f9f1bba9-6a90-4d79-a223-dd869db7263d.PNG" width="240" /> 

